### PR TITLE
Fix invalid appearance in Apros due to their box-sizing global

### DIFF
--- a/problem_builder/public/css/questionnaire.css
+++ b/problem_builder/public/css/questionnaire.css
@@ -78,10 +78,13 @@
     display: table-cell;
     vertical-align: top;
     width: 28px;
+    padding-top: 3px;
+    padding-right: 5px;
 }
 
 .mentoring .choice-label {
     display: table-cell;
     vertical-align: top;
     line-height: 1.3;
+    padding-top: 4px;
 }

--- a/problem_builder/public/css/questionnaire.css
+++ b/problem_builder/public/css/questionnaire.css
@@ -37,7 +37,7 @@
     font-family: arial;
     font-size: 14px;
     opacity: 0.9;
-    padding: 22px 10px;
+    padding: 22px 10px 10px 10px;
     width: 300px;
     min-height: 40px;
     z-index: 10000;

--- a/problem_builder/public/themes/apros.css
+++ b/problem_builder/public/themes/apros.css
@@ -1,0 +1,4 @@
+.mentoring .questionnaire .choice-tips,
+.mentoring .questionnaire .feedback {
+    box-sizing: content-box;  /* Avoid a global reset to border-box found on Apros */
+}

--- a/problem_builder/public/themes/apros.css
+++ b/problem_builder/public/themes/apros.css
@@ -2,3 +2,8 @@
 .mentoring .questionnaire .feedback {
     box-sizing: content-box;  /* Avoid a global reset to border-box found on Apros */
 }
+
+.themed-xblock.mentoring .choices-list .choice-selector {
+    padding: 4px 3px 0 3px;
+    font-size: 16px;
+}

--- a/problem_builder/public/themes/lms.css
+++ b/problem_builder/public/themes/lms.css
@@ -42,7 +42,6 @@ div.course-wrapper section.course-content .themed-xblock.mentoring p:empty {
     vertical-align: middle;
     width: 100%;
     padding-bottom: 10px;
-    padding-top: 2px;
 }
 
 .themed-xblock.mentoring .choice-label span.low {

--- a/problem_builder/questionnaire.py
+++ b/problem_builder/questionnaire.py
@@ -21,10 +21,10 @@
 # Imports ###########################################################
 
 from django.utils.safestring import mark_safe
-import logging
-from lxml import etree
+from lazy import lazy
+import uuid
 from xblock.core import XBlock
-from xblock.fields import Scope, String, Float, List, UNIQUE_ID
+from xblock.fields import Scope, String, Float, UNIQUE_ID
 from xblock.fragment import Fragment
 from xblock.validation import ValidationMessage
 from xblockutils.helpers import child_isinstance
@@ -90,14 +90,14 @@ class QuestionnaireAbstractBlock(StudioEditableXBlockMixin, StudioContainerXBloc
         """ translate text """
         return self.runtime.service(self, "i18n").ugettext(text)
 
-    @property
+    @lazy
     def html_id(self):
         """
         A short, simple ID string used to uniquely identify this question.
 
         This is only used by templates for matching <input> and <label> elements.
         """
-        return unicode(id(self))  # Unique as long as all choices are loaded at once
+        return uuid.uuid4().hex[:20]
 
     def student_view(self, context=None):
         name = getattr(self, "unmixed_class", self.__class__).__name__

--- a/problem_builder/tests/integration/test_dashboard.py
+++ b/problem_builder/tests/integration/test_dashboard.py
@@ -175,6 +175,7 @@ class TestDashboardBlock(SeleniumXBlockTest):
                 choices = mcq.find_elements_by_css_selector('.choices .choice label')
                 choices[idx].click()
             submit = pb.find_element_by_css_selector('.submit input.input-main')
+            self.assertTrue(submit.is_enabled())
             submit.click()
             self.wait_until_disabled(submit)
 


### PR DESCRIPTION
Apros CSS has the rule `*, *:before, *:after { box-sizing: border-box; }`, which (not surprisingly) messes up the layout of our tip popups.

**Before screenshot**:
![apros-before](https://cloud.githubusercontent.com/assets/945577/7059185/615ecdc8-de21-11e4-914c-00527d8cdd45.png)

**After screenshot**:
![apros-after](https://cloud.githubusercontent.com/assets/945577/7059187/66f6a3a0-de21-11e4-97cb-0ff69f711dfc.png)

**Testing instructions**:
* Use a birch rebase branch of the solutions fork of edx-platform. The only one that's currently working for me is [braden/birch-rebase-testing](https://github.com/edx-solutions/edx-platform/commits/braden/birch-rebase-testing)
* Add the following to `~/lms.env.json`:

  ```json
    "XBLOCK_SETTINGS": {
        "mentoring": {
            "theme": {
                "package": "problem_builder",
                "locations": ["public/themes/apros.css"]
            }
        }
    }
   ```
* Open Apros and look at an MCQ/MRQ with tips.