### PR TITLE
Hotfix: Four minor issues to address before release

### DIFF
--- a/problem_builder/mcq.py
+++ b/problem_builder/mcq.py
@@ -133,9 +133,7 @@ class MCQBlock(SubmittingXBlockMixin, QuestionnaireAbstractBlock):
         all_values = set(self.all_choice_values)
         correct = set(data.correct_choices)
 
-        if not all_values:
-            add_error(self._(u"No choices set yet."))
-        elif not correct:
+        if all_values and not correct:
             add_error(
                 self._(u"You must indicate the correct answer[s], or the student will always get this question wrong.")
             )

--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -505,15 +505,6 @@ class MentoringBlock(XBlock, StepParentMixin, StudioEditableXBlockMixin, StudioC
                 html += child.render('mentoring_view', {}).content  # TODO: frament_text_rewriting ?
         return html
 
-    def clean_studio_edits(self, data):
-        """
-        Given POST data dictionary 'data', clean the data before validating it.
-        e.g. fix capitalization, remove trailing spaces, etc.
-        """
-        if data.get('mode') == 'assessment' and 'max_attempts' not in data:
-            # assessment has a default of 2 max_attempts
-            data['max_attempts'] = 2
-
     def validate(self):
         """
         Validates the state of this XBlock except for individual field values.

--- a/problem_builder/public/css/mentoring.css
+++ b/problem_builder/public/css/mentoring.css
@@ -40,12 +40,13 @@
     font-style: italic;
 }
 
-.mentoring h4 {
-    margin-bottom: 20px;
+.mentoring fieldset {
+    margin-top: 10px;
 }
 
-.mentoring h4 {
-    margin-top: 25px;
+.mentoring h3 {
+    margin-top: 0px;
+    margin-bottom: 7px;
 }
 
 .mentoring .submit {
@@ -60,6 +61,10 @@
 .mentoring legend {
     white-space: normal;
     display: table; /* Enable line-wrapping in IE8 */
+}
+
+.mentoring .choices legend.question p:last-child { /* Selector must be more specific than 'div.course-wrapper section.course-content p' */
+    margin-bottom: 0;
 }
 
 .mentoring .attempts {

--- a/problem_builder/public/js/mentoring_assessment_view.js
+++ b/problem_builder/public/js/mentoring_assessment_view.js
@@ -33,10 +33,9 @@ function MentoringAssessmentView(runtime, element, mentoring) {
         tryAgainDOM.show();
 
         var attempts_data = $('.attempts', element).data();
-        if (attempts_data.num_attempts >= attempts_data.max_attempts) {
+        if (attempts_data.max_attempts > 0 && attempts_data.num_attempts >= attempts_data.max_attempts) {
             tryAgainDOM.attr("disabled", "disabled");
-        }
-        else {
+        } else {
             tryAgainDOM.removeAttr("disabled");
         }
 

--- a/problem_builder/questionnaire.py
+++ b/problem_builder/questionnaire.py
@@ -93,7 +93,7 @@ class QuestionnaireAbstractBlock(StudioEditableXBlockMixin, StudioContainerXBloc
 
         template_path = 'templates/html/{}.html'.format(name.lower())
 
-        context = context or {}
+        context = context.copy() if context else {}
         context['self'] = self
         context['custom_choices'] = self.custom_choices
         context['hide_header'] = context.get('hide_header', False) or not self.show_title


### PR DESCRIPTION
**Description**: The `edx-release` branch contains only the code that has been reviewed by both OpenCraft and edX for release on edX.org. In testing that release branch, we found a few minor issues which this PR addresses.

Fixes:
* Bug: MCQ/MRQ question titles were not visible in the LMS, even when "Show Title" was true, if another MCQ/MRQ that came earlier in the same subsection had show_title set false.  
  Fixed with 45072bbc661d9306fa751295e276827ab5fef3b7
* Usability improvement: In Studio, an MCQ's question text could not be set until at least one choice was created. In addition, a validation warning was shown immediately when adding an MCQ.  
  Fixed with 3d4bf295bd760526a97735102fb448ccb28889a9
* Bug: If a problem builder in assessment mode had max_attempts=2, then a student completes one attempt, then max_attempts was changed to 0 (unlimited) by the course author, that student is unable to try again.  
  Fixed with 8bf362dd1edd7359393a812014213bbb8f079e95
* Usability improvement: the default value of "max_attempts" would change when the "mode" setting was changed, but it would only change after the user closed the edit dialog. This was confusing, as the value would not match what the user just saw. For now I have just removed this behaviour so that the default value is always '0' (no limit) and it never changes unless manually set by the user.  
  Fixed with 0d85a3fe174ab063aedeaa68b0d9a5b0e00e1ec4

Once these fixes are reviewed and approved here, I am also planning to cherry-pick them onto our master (development) branch.

Sandbox: http://sandbox2.opencraft.com:18010/