### PR TITLE
Fix: Checkmark not shown if answer name is numeric

### DIFF
--- a/problem_builder/public/js/mentoring.js
+++ b/problem_builder/public/js/mentoring.js
@@ -106,7 +106,7 @@ function MentoringBlock(runtime, element) {
     function getChildByName(name) {
         for (var i = 0; i < children.length; i++) {
             var child = children[i];
-            if (child && child.name === name) {
+            if (child && child.name.toString() === name) {
                 return child;
             }
         }

--- a/problem_builder/public/js/mentoring_assessment_view.js
+++ b/problem_builder/public/js/mentoring_assessment_view.js
@@ -196,7 +196,7 @@ function MentoringAssessmentView(runtime, element, mentoring) {
         if (fire_event) {
             mentoring.publish_event({
                 event_type: 'xblock.problem_builder.assessment.shown',
-                exercise_id: child.name
+                exercise_id: child.name.toString()
             });
         }
     }
@@ -291,7 +291,7 @@ function MentoringAssessmentView(runtime, element, mentoring) {
         var data = {};
         var child = mentoring.steps[active_child];
         if (child && child.name !== undefined) {
-            data[child.name] = callIfExists(child, handler_name);
+            data[child.name.toString()] = callIfExists(child, handler_name);
         }
         var handlerUrl = runtime.handlerUrl(element, handler_name);
         if (submitXHR) {

--- a/problem_builder/public/js/mentoring_standard_view.js
+++ b/problem_builder/public/js/mentoring_standard_view.js
@@ -38,7 +38,7 @@ function MentoringStandardView(runtime, element, mentoring) {
         for (var i = 0; i < children.length; i++) {
             var child = children[i];
             if (child && child.name !== undefined && typeof(child[handler_name]) !== "undefined") {
-                data[child.name] = child[handler_name]();
+                data[child.name.toString()] = child[handler_name]();
             }
         }
         var handlerUrl = runtime.handlerUrl(element, handler_name);
@@ -53,7 +53,7 @@ function MentoringStandardView(runtime, element, mentoring) {
     }
 
     function submit() {
-        calculate_results('submit')
+        calculate_results('submit');
     }
 
     function clearResults() {


### PR DESCRIPTION
I found an issue while testing birch rebase: If a Problem Builder contains a Long Answer field with a "name" that is numeric (e.g. "1234"), then the checkmark does not appear after you submit your answer. (Everything works fine though, just the checkmark is missing).