### PR TITLE
Hotfix for OC-639: Database conflict between mentoring and problem_builder

### DIFF
--- a/problem_builder/models.py
+++ b/problem_builder/models.py
@@ -29,10 +29,11 @@ class Answer(models.Model):
     """
     Django model used to store AnswerBlock data that need to be shared
     and queried accross XBlock instances (workaround).
+
+    TODO: Deprecate this and move to edx-submissions
     """
 
     class Meta:
-        db_table = 'mentoring_answer'
         unique_together = (('student_id', 'course_id', 'name'),)
 
     name = models.CharField(max_length=50, db_index=True)

--- a/problem_builder/south_migrations/0001_initial.py
+++ b/problem_builder/south_migrations/0001_initial.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from south.db import db
+from south.v2 import SchemaMigration
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Answer'
+        db.create_table('problem_builder_answer', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=50, db_index=True)),
+            ('student_id', self.gf('django.db.models.fields.CharField')(max_length=32, db_index=True)),
+            ('course_id', self.gf('django.db.models.fields.CharField')(max_length=50, db_index=True)),
+            ('student_input', self.gf('django.db.models.fields.TextField')(default='', blank=True)),
+            ('created_on', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
+            ('modified_on', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, blank=True)),
+        ))
+        db.send_create_signal('problem_builder', ['Answer'])
+
+        # Adding unique constraint on 'Answer', fields ['student_id', 'course_id', 'name']
+        db.create_unique('problem_builder_answer', ['student_id', 'course_id', 'name'])
+
+    def backwards(self, orm):
+        # Removing unique constraint on 'Answer', fields ['student_id', 'course_id', 'name']
+        db.delete_unique('problem_builder_answer', ['student_id', 'course_id', 'name'])
+
+        # Deleting model 'Answer'
+        db.delete_table('problem_builder_answer')
+
+    models = {
+        'problem_builder.answer': {
+            'Meta': {'unique_together': "(('student_id', 'course_id', 'name'),)", 'object_name': 'Answer'},
+            'course_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified_on': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'student_id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'student_input': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['problem_builder']

--- a/problem_builder/south_migrations/0002_copy_from_mentoring.py
+++ b/problem_builder/south_migrations/0002_copy_from_mentoring.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+from django.db.utils import DatabaseError
+from south.db import db
+from south.v2 import DataMigration
+
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        """
+        Copy student data from old table to the new one.
+
+        Problem Builder stores student answers in 'problem_builder_answer'.
+        However earlier versions [may have] used 'mentoring_answer'.
+        If a 'mentoring' app is currently installed on this instance, copy the student data over
+        to the new table in case it is being used.
+        """
+        try:
+            db.execute(
+                'INSERT INTO problem_builder_answer ('
+                'name, student_id, course_id, student_input, created_on, modified_on '
+                ') SELECT '
+                'name, student_id, course_id, student_input, created_on, modified_on '
+                'FROM mentoring_answer'
+            )
+        except DatabaseError:  # Would like to just catch 'Table does not exist' but can't do that in a db-agnostic way
+            print(" - Seems like mentoring_answer does not exist. No data migration needed.")
+
+    def backwards(self, orm):
+        raise RuntimeError("Cannot safely reverse this migration.")
+
+    models = {
+        'problem_builder.answer': {
+            'Meta': {'unique_together': "(('student_id', 'course_id', 'name'),)", 'object_name': 'Answer'},
+            'course_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'created_on': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified_on': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'student_id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'student_input': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['problem_builder']
+    symmetrical = True


### PR DESCRIPTION
Hotfix for OC-639:

**Bug details**:
The old mentoring XBlock uses South migrations to create a table called `mentoring_answers`. The new Problem Builder XBlock uses syncdb to create a table also called `mentoring_answers`.

Unfortunately, if a new edX instance is spun up and mentoring v1 and Problem Builder are both being installed at the same time (as they are if `requirements/edx/edx-private.txt` is used), there will be a database error since the South migration will abort when it finds that the table already exists: https://gist.github.com/maxrothman/3868d5e7ad87533a287c

Because syncdb does nothing if the table already exists, an edX instance could only have both blocks installed as long as mentoring was installed and setup in the DB first.

**Fix details**:
My proposed fix is just to rename the table in Problem Builder. I've also added a data migration that copies *all* student answers from the `mentoring_answers` table to the new table, which should prevent any students who may be currently using problem builder from losing data.

**Consequences**:
* Running the upgrade script that converts from the old block to the new one will no longer automagically migrate any student answers made since problem builder was installed. However, I don't really want anyone attempting to do that upgrade on a course that students are using anyways.

**Recovery**:  
If someone encountered the error seen in the gist link above, it should be possible to recover with:
```bash
./manage.py lms migrate mentoring 0003 --fake --settings=devstack
```
(Change `devstack` to whatever configuration is being used)