### PR TITLE
Allowed overriding average labels per mentoring

### DIFF
--- a/problem_builder/templates/html/dashboard.html
+++ b/problem_builder/templates/html/dashboard.html
@@ -56,7 +56,7 @@
           {% endfor %}
           {% if block.has_average %}
            <tr class="avg-row">
-              <th class="desc">{{ average_label }}</th>
+              <th class="desc">{{ block.average_label }}</th>
               <td class="value"
                   {% if block.average_color %} style="border-right-color: {{block.average_color}};"{% endif %}
                   {% if not show_numbers %}

--- a/problem_builder/tests/integration/test_dashboard.py
+++ b/problem_builder/tests/integration/test_dashboard.py
@@ -58,11 +58,13 @@ class TestDashboardBlock(SeleniumXBlockTest):
     """
     SIMPLE_DASHBOARD = """<pb-dashboard mentoring_ids='["dummy-value"]'/>"""
     ALTERNATIVE_DASHBOARD = dedent("""
-    <pb-dashboard mentoring_ids='["dummy-value"]' average_label="Avg." show_numbers="false"/>
+    <pb-dashboard mentoring_ids='["dummy-value"]' show_numbers="false"
+        average_labels='{"Step 1": "Avg.", "Step 2":"Mean", "Step 3":"Second Quartile"}'
+    />
     """)
     HIDE_QUESTIONS_DASHBOARD = dedent("""
     <pb-dashboard mentoring_ids='["dummy-value"]'
-      exclude_questions='{"Step 1": [2, 3], "Step 2":[3], "Step 3":[2]}'
+        exclude_questions='{"Step 1": [2, 3], "Step 2":[3], "Step 3":[2]}'
     />
     """)
     MALFORMED_HIDE_QUESTIONS_DASHBOARD = dedent("""
@@ -185,7 +187,9 @@ class TestDashboardBlock(SeleniumXBlockTest):
         steps = dashboard.find_elements_by_css_selector('tbody')
         self.assertEqual(len(steps), 3)
 
-        for step in steps:
+        average_labels = ["Avg.", "Mean", "Second Quartile"]
+
+        for step_num, step in enumerate(steps):
             mcq_rows = step.find_elements_by_css_selector('tr:not(.avg-row)')
             self.assertTrue(2 <= len(mcq_rows) <= 3)
             for mcq in mcq_rows:
@@ -194,7 +198,7 @@ class TestDashboardBlock(SeleniumXBlockTest):
             # Check the average:
             avg_row = step.find_element_by_css_selector('tr.avg-row')
             left_col = avg_row.find_element_by_css_selector('.desc')
-            self.assertEqual(left_col.text, "Avg.")
+            self.assertEqual(left_col.text, average_labels[step_num])
             right_col = avg_row.find_element_by_css_selector('.value')
             self.assertEqual(right_col.text, "")
 


### PR DESCRIPTION
**JIRA Ticket:** https://openedx.atlassian.net/browse/OSPR-543
**Details:** See JIRA ticket
**Sandbox:** [LMS](http://sandbox4.opencraft.com/courses/course-v1:edX+PB101+now/courseware/ee978680a3bc409a93e1e5d2efac7787/1654a7e6c6244bb18d6fd729b9f26557/), [CMS](http://sandbox4.opencraft.com:18010/container/block-v1:edX+PB101+now+type@vertical+block@977dea6433d044ddaac7389138175751?action=new)
**Merge deadline:** Preferably Friday 24th (in time for upcoming release).

**Testing instructions:**

1. Set up a couple of mentoring XBlocks
2, Set up Dashboard block to draw data from those blocks
3. Set custom values for "Label for average value" for some (or all) mentoring blocks
4. Publish
5. Go to LMS, provide answers for mentoring blocks
6. Navigate to dashboard block

Observe the following:
* Average values have custom labels specified at step 3.