### PR TITLE
Hide "Review final grade" link by default.

### DIFF
--- a/problem_builder/public/css/mentoring.css
+++ b/problem_builder/public/css/mentoring.css
@@ -165,4 +165,5 @@
 
 .mentoring .review-link {
     float: right;
+    display: none;
 }

--- a/problem_builder/public/js/mentoring_assessment_view.js
+++ b/problem_builder/public/js/mentoring_assessment_view.js
@@ -102,7 +102,6 @@ function MentoringAssessmentView(runtime, element, mentoring) {
         checkmark = $('.assessment-checkmark', element);
         messagesDOM = $('.assessment-messages', element);
 
-        reviewLinkDOM.hide();
         submitDOM.show();
         submitDOM.bind('click', submit);
         nextDOM.bind('click', displayNextChild);

--- a/problem_builder/public/js/mentoring_standard_view.js
+++ b/problem_builder/public/js/mentoring_standard_view.js
@@ -75,8 +75,6 @@ function MentoringStandardView(runtime, element, mentoring) {
         submitDOM = $(element).find('.submit .input-main');
         submitDOM.bind('click', submit);
         submitDOM.show();
-        // Not used in standard mode.
-        $(element).find('.review-link').hide();
 
         var options = {
             onChange: onChange


### PR DESCRIPTION
The link is only used during extended feedback in assessment mode.  It's hidden
on page load by JS in all cases, and only shown if the student goes back to a
question after using up all attempts, so we can just as well hide it in CSS.

This fixes MCKIN-3099.

@bradenmacdonald I can't reproduce the issue on my local Apros installation, neither with Firefox nor with Chrome.  I can reproduce it using the link and credentials in MCKIN-3099, though, so it's probably dependent on the timing of AJAX responses, or something along these lines.  Could you please try whether you are able to reproduce the issue, and whether this patch fixes it?  I'm rather confident it does.

The issue occurs when moving forward (or back) to a unit with a mentoring question in standard mode using the blue Apros navigation arrows -- see the video in MCKIN-3099.