### PR TITLE
Fix upgrade error when <message> has no 'type' specified explicitly

### DIFF
--- a/problem_builder/message.py
+++ b/problem_builder/message.py
@@ -159,7 +159,8 @@ class MentoringMessageBlock(XBlock, StudioEditableXBlockMixin):
         """
         block = runtime.construct_xblock_from_class(cls, keys)
         block.content = unicode(node.text or u"")
-        block.type = node.attrib['type']
+        if 'type' in node.attrib:  # 'type' is optional - default is 'completed'
+            block.type = node.attrib['type']
         for child in node:
             block.content += etree.tostring(child, encoding='unicode')
 

--- a/problem_builder/v1/tests/xml/v1_upgrade_a_new.xml
+++ b/problem_builder/v1/tests/xml/v1_upgrade_a_new.xml
@@ -31,7 +31,7 @@
     <pb-tip values='["elegance","beauty"]'>This is something everyone has to like about this MRQ</pb-tip>
     <pb-tip values='["bugs"]'>Nah, there aren't any!</pb-tip>
   </pb-mrq>
-  <pb-message type="completed">
+  <pb-message>
     <p>Congratulations!</p>
   </pb-message>
   <pb-message type="incomplete">

--- a/problem_builder/v1/tests/xml/v1_upgrade_a_old.xml
+++ b/problem_builder/v1/tests/xml/v1_upgrade_a_old.xml
@@ -56,7 +56,7 @@ Changes from the original:
                     <message type="on-submit">Thank you for answering!</message>
                 </mrq>
 
-                <message type="completed">
+                <message>
                     <html><p>Congratulations!</p></html>
                 </message>
                 <message type="incomplete">


### PR DESCRIPTION
This PR addresses OC-694. The issue was caused by the XML parser expecting the "type" attribute to always be present, when in fact it is optional and has a default value of "completed".

I fixed the custom xml parser so it doesn't require that attribute, and I updated the relevant test to check for this.