### PR TITLE
Minor tweaks to better match the Apros theme

### DIFF
--- a/problem_builder/public/themes/apros.css
+++ b/problem_builder/public/themes/apros.css
@@ -7,3 +7,12 @@
     padding: 4px 3px 0 3px;
     font-size: 16px;
 }
+
+.mentoring .title h2 {
+	/* Same as h2.main in Apros */
+	color: #66a5b5;
+}
+
+.mentoring h3 {
+    text-transform: uppercase;
+}

--- a/problem_builder/tests/integration/base_test.py
+++ b/problem_builder/tests/integration/base_test.py
@@ -133,9 +133,10 @@ class MentoringAssessmentBaseTest(ProblemBuilderBaseTest):
 
         return mentoring, controls
 
-    def expect_question_visible(self, number, mentoring):
-        question_text = self.question_text(number)
-        self.wait_until_text_in(self.question_text(number), mentoring)
+    def expect_question_visible(self, number, mentoring, question_text=None):
+        if not question_text:
+            question_text = self.question_text(number)
+        self.wait_until_text_in(question_text, mentoring)
         question_div = None
         for xblock_div in mentoring.find_elements_by_css_selector('div.xblock-v1'):
             header_text = xblock_div.find_elements_by_css_selector('h3.question-title')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ddt
 mock
 unicodecsv==0.9.4
--e git+https://github.com/edx/xblock-utils.git@a0e77eeb4eb971ac57243fe1056dd8db6806f514#egg=xblock-utils
+-e git+https://github.com/edx/xblock-utils.git@213a97a50276d6a2504d8133650b2930ead357a0#egg=xblock-utils
 -e .

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/edx/XBlock.git@496d3cb9aca1d9e0a18b0f5e73c7bede824e465f#egg=XBlock
+-e git+https://github.com/edx/XBlock.git@tag-master-2015-05-22#egg=XBlock


### PR DESCRIPTION
When the Apros theme is active, this makes the main header (an `h2`) match the color of Apros `<h2 class="main">` headers. It also makes the subheaders use all-caps, as Apros does.

Screenshot:
![screen shot 2015-06-12 at 2 34 19 pm](https://cloud.githubusercontent.com/assets/945577/8140564/96aafa1a-1111-11e5-814a-1eafec64bc4a.png)
