### PR TITLE
Export bugfixes

### DIFF
--- a/problem_builder/data_export.py
+++ b/problem_builder/data_export.py
@@ -172,6 +172,8 @@ class DataExportBlock(XBlock):
             return {'error': 'permission denied'}
         from .tasks import export_data as export_data_task  # Import here since this is edX LMS specific
         self._delete_export()
+        # Make sure we nail down our state before sending off an asynchronous task.
+        self.save()
         if not username:
             user_id = None
         else:

--- a/problem_builder/public/js/data_export.js
+++ b/problem_builder/public/js/data_export.js
@@ -26,7 +26,7 @@ function DataExportBlock(runtime, element) {
     }
 
     function updateStatus(newStatus) {
-        var statusChanged = newStatus !== status;
+        var statusChanged = ! _.isEqual(newStatus, status);
         status = newStatus;
         if (status.export_pending) {
             // Keep polling for status updates when an export is running.

--- a/problem_builder/tasks.py
+++ b/problem_builder/tasks.py
@@ -9,6 +9,7 @@ from instructor_task.models import ReportStore
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import UsageKey, CourseKey
 from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.exceptions import ItemNotFoundError
 
 from .mcq import MCQBlock, RatingBlock
 from problem_builder import AnswerBlock
@@ -56,7 +57,11 @@ def export_data(course_id, source_block_id_str, block_types, user_id, get_root=T
             blocks_to_include.append(block)
         elif block.has_children:
             for child_id in block.children:
-                scan_for_blocks(block.runtime.get_block(child_id))
+                try:
+                    scan_for_blocks(block.runtime.get_block(child_id))
+                except ItemNotFoundError:
+                    # Blocks may refer to missing children. Don't break in this case.
+                    pass
 
     scan_for_blocks(root)
 


### PR DESCRIPTION
@mtyaka @itsjeyd 

This PR contains two commits-- one of which is for the issue of missing children causing a crash, and one may resolve the issue where the download button was hidden.

A few notes:

1. I don't have access to the Harvard instance, and I can't reproduce this locally, so this fix is my best guess. I might have an easier time of it if I can see it in person. @mtyaka , would you be able to show me where this is and get me set up with it?
2. The primary fix for the download button is fixing a conditional that would always be true (objects only ever equal themselves in Javascript. Deep equality is not checked). I believe that this assumption might cause a race condition whereby the updateStatus information might be updated twice rapidly with two different sets of information.
3. A (probably unneccessary-- @bradenmacdonald can you comment?) additional change was forcing a save of the fields on the XBlock before firing off the task, lest the task end before the fields were saved and the result be overwritten. I don't know if this is a realistic fear, but because I couldn't reproduce the issue and it seemed plausible that this sort of thing might cause the issue, I added that as well.