### PR TITLE
Instructor Tool: Drop-down for "Root block ID" section, pagination improvements (OC-783)

### DIFF
--- a/problem_builder/instructor_tool.py
+++ b/problem_builder/instructor_tool.py
@@ -134,7 +134,7 @@ class InstructorToolBlock(XBlock):
             _('Rating Question'): 'RatingBlock',
             _('Long Answer'): 'AnswerBlock',
         }
-        block_types = ('pb-mcq', 'pb-rating', 'pb-answer')
+        eligible_block_types = ('pb-mcq', 'pb-rating', 'pb-answer')
         flat_block_tree = []
 
         def get_block_id(block):
@@ -155,18 +155,10 @@ class InstructorToolBlock(XBlock):
               - block.display_name
               - block ID
             """
-            # - Try "question" attribute:
-            block_name = getattr(block, 'question', None)
-            if not block_name:
-                # Try question ID (name):
-                block_name = getattr(block, 'name', None)
-            if not block_name:
-                # - Try display_name:
-                block_name = getattr(block, 'display_name', None)
-            if not block_name:
-                # - Default to ID:
-                block_name = get_block_id(block)
-            return block_name
+            for attribute in ('question', 'name', 'display_name'):
+                if getattr(block, attribute, None):
+                    return getattr(block, attribute, None)
+            return get_block_id(block)
 
         def get_block_type(block):
             """
@@ -185,8 +177,8 @@ class InstructorToolBlock(XBlock):
             block_id = get_block_id(block)
             block_name = get_block_name(block)
             block_type = get_block_type(block)
-            if not block_type == 'pb-choice':
-                eligible = block_type in block_types
+            if block_type != 'pb-choice':
+                eligible = block_type in eligible_block_types
                 if eligible:
                     # If this block is a question whose answers we can export,
                     # we mark all of its ancestors as exportable too

--- a/problem_builder/instructor_tool.py
+++ b/problem_builder/instructor_tool.py
@@ -156,7 +156,10 @@ class InstructorToolBlock(XBlock):
               - block ID
             """
             # - Try "question" attribute:
-            block_name = getattr(block, 'question', block.name)
+            block_name = getattr(block, 'question', None)
+            if not block_name:
+                # Try question ID (name):
+                block_name = getattr(block, 'name', None)
             if not block_name:
                 # - Try display_name:
                 block_name = getattr(block, 'display_name', None)

--- a/problem_builder/instructor_tool.py
+++ b/problem_builder/instructor_tool.py
@@ -136,7 +136,9 @@ class InstructorToolBlock(XBlock):
             """
             Build up a tree of information about the XBlocks descending from root_block
             """
-            block_id = block.scope_ids.usage_id.block_id
+            block_id = block.scope_ids.usage_id
+            # Block ID not in workbench runtime.
+            block_id = unicode(getattr(block_id, 'block_id', block_id))
             block_name = getattr(block, "display_name", None)
             block_type = block.runtime.id_reader.get_block_type(block.scope_ids.def_id)
             if not block_name and block_type in block_types:
@@ -163,12 +165,16 @@ class InstructorToolBlock(XBlock):
         root_block = self
         while root_block.parent:
             root_block = root_block.get_parent()
+        root_block_id = root_block.scope_ids.usage_id
+        # Block ID not in workbench runtime.
+        root_block_id = unicode(getattr(root_block_id, 'block_id', root_block_id))
         root_entry = {
             "depth": 0,
-            "id": root_block.scope_ids.usage_id.block_id,
+            "id": root_block_id,
             "name": "All",
         }
         flat_block_tree.append(root_entry)
+
         for child_id in root_block.children:
             child_block = root_block.runtime.get_block(child_id)
             build_tree(child_block, [root_entry])

--- a/problem_builder/instructor_tool.py
+++ b/problem_builder/instructor_tool.py
@@ -142,7 +142,7 @@ class InstructorToolBlock(XBlock):
             block_name = getattr(block, "display_name", None)
             block_type = block.runtime.id_reader.get_block_type(block.scope_ids.def_id)
             if not block_name and block_type in block_types:
-                block_name = block.question
+                block_name = getattr(block, 'question', block.name)
             eligible = block_type in block_types
             if eligible:
                 # If this block is a question whose answers we can export,

--- a/problem_builder/instructor_tool.py
+++ b/problem_builder/instructor_tool.py
@@ -84,6 +84,11 @@ class InstructorToolBlock(XBlock):
         # different celery queues; our task listener is waiting for tasks on the LMS queue)
         return Fragment(u'<p>Instructor Tool Block</p><p>This block only works from the LMS.</p>')
 
+    def studio_view(self, context=None):
+        """ View for editing Instructor Tool block in Studio. """
+        # Display friendly message explaining that the block is not editable.
+        return Fragment(u'<p>This is a preconfigured block. It is not editable.</p>')
+
     def check_pending_export(self):
         """
         If we're waiting for an export, see if it has finished, and if so, get the result.

--- a/problem_builder/instructor_tool.py
+++ b/problem_builder/instructor_tool.py
@@ -137,13 +137,18 @@ class InstructorToolBlock(XBlock):
         block_types = ('pb-mcq', 'pb-rating', 'pb-answer')
         flat_block_tree = []
 
+        def get_block_id(block):
+            """
+            Return ID of `block`, taking into account needs of both LMS/CMS and workbench runtimes.
+            """
+            usage_id = block.scope_ids.usage_id
+            # Try accessing block ID. If usage_id does not have it, return usage_id itself
+            return unicode(getattr(usage_id, 'block_id', usage_id))
+
         def build_tree(block, ancestors):
             """
             Build up a tree of information about the XBlocks descending from root_block
             """
-            block_id = block.scope_ids.usage_id
-            # Block ID not in workbench runtime.
-            block_id = unicode(getattr(block_id, 'block_id', block_id))
             block_name = getattr(block, "display_name", None)
             block_type = block.runtime.id_reader.get_block_type(block.scope_ids.def_id)
             if not block_name and block_type in block_types:
@@ -157,7 +162,7 @@ class InstructorToolBlock(XBlock):
                         ancestor["eligible"] = True
             new_entry = {
                 "depth": len(ancestors),
-                "id": block_id,
+                "id": get_block_id(block),
                 "name": block_name,
                 "eligible": eligible,
             }
@@ -170,9 +175,7 @@ class InstructorToolBlock(XBlock):
         root_block = self
         while root_block.parent:
             root_block = root_block.get_parent()
-        root_block_id = root_block.scope_ids.usage_id
-        # Block ID not in workbench runtime.
-        root_block_id = unicode(getattr(root_block_id, 'block_id', root_block_id))
+        root_block_id = get_block_id(root_block)
         root_entry = {
             "depth": 0,
             "id": root_block_id,

--- a/problem_builder/instructor_tool.py
+++ b/problem_builder/instructor_tool.py
@@ -189,24 +189,25 @@ class InstructorToolBlock(XBlock):
             block_id = get_block_id(block)
             block_name = get_block_name(block)
             block_type = get_block_type(block)
-            eligible = block_type in block_types
-            if eligible:
-                # If this block is a question whose answers we can export,
-                # we mark all of its ancestors as exportable too
-                if ancestors and not ancestors[-1]["eligible"]:
-                    for ancestor in ancestors:
-                        ancestor["eligible"] = True
-            new_entry = {
-                "depth": len(ancestors),
-                "id": block_id,
-                "name": block_name,
-                "eligible": eligible,
-            }
-            flat_block_tree.append(new_entry)
-            if block.has_children and not block_type == 'pb-mcq' and not \
-               getattr(block, "has_dynamic_children", lambda: False)():
-                for child_id in block.children:
-                    build_tree(block.runtime.get_block(child_id), ancestors=(ancestors + [new_entry]))
+            if not block_type == 'pb-choice':
+                eligible = block_type in block_types
+                if eligible:
+                    # If this block is a question whose answers we can export,
+                    # we mark all of its ancestors as exportable too
+                    if ancestors and not ancestors[-1]["eligible"]:
+                        for ancestor in ancestors:
+                            ancestor["eligible"] = True
+
+                new_entry = {
+                    "depth": len(ancestors),
+                    "id": block_id,
+                    "name": block_name,
+                    "eligible": eligible,
+                }
+                flat_block_tree.append(new_entry)
+                if block.has_children and not getattr(block, "has_dynamic_children", lambda: False)():
+                    for child_id in block.children:
+                        build_tree(block.runtime.get_block(child_id), ancestors=(ancestors + [new_entry]))
 
         root_block = self
         while root_block.parent:

--- a/problem_builder/instructor_tool.py
+++ b/problem_builder/instructor_tool.py
@@ -149,21 +149,14 @@ class InstructorToolBlock(XBlock):
             """
             Return name of `block`.
 
-            - For MCQs, Ratings, Answer blocks this is one of:
+            Try attributes in the following order:
               - block.question
               - block.name (fallback for old courses)
-            - For other types of (non-eligible) blocks this is one of:
-              - block.question
               - block.display_name
-              - block ID (fallback if neither 'question' nor 'display_name' is suitable)
+              - block ID
             """
-            block_type = get_block_type(block)
-            # Eligible block (question)
-            if block_type in block_types:
-                return getattr(block, 'question', block.name)
-            # Non-eligible block (question or section/subsection/unit)
             # - Try "question" attribute:
-            block_name = getattr(block, 'question', None)
+            block_name = getattr(block, 'question', block.name)
             if not block_name:
                 # - Try display_name:
                 block_name = getattr(block, 'display_name', None)

--- a/problem_builder/instructor_tool.py
+++ b/problem_builder/instructor_tool.py
@@ -145,12 +145,22 @@ class InstructorToolBlock(XBlock):
             # Try accessing block ID. If usage_id does not have it, return usage_id itself
             return unicode(getattr(usage_id, 'block_id', usage_id))
 
+        def get_block_type(block):
+            """
+            Return type of `block`, taking into account different key styles that might be in use.
+            """
+            try:
+                block_type = block.runtime.id_reader.get_block_type(block.scope_ids.def_id)
+            except AttributeError:
+                block_type = block.runtime.id_reader.get_block_type(block.scope_ids.usage_id)
+            return block_type
+
         def build_tree(block, ancestors):
             """
             Build up a tree of information about the XBlocks descending from root_block
             """
             block_name = getattr(block, "display_name", None)
-            block_type = block.runtime.id_reader.get_block_type(block.scope_ids.def_id)
+            block_type = get_block_type(block)
             if not block_name and block_type in block_types:
                 block_name = getattr(block, 'question', block.name)
             eligible = block_type in block_types

--- a/problem_builder/public/css/instructor_tool.css
+++ b/problem_builder/public/css/instructor_tool.css
@@ -26,7 +26,7 @@
     padding-left: 1em;
 }
 .data-export-field-container {
-    min-width: 45%;
+    width: 43%;
 }
 .data-export-options .data-export-actions {
     max-width: 10%;
@@ -40,7 +40,7 @@
     vertical-align: middle;
 }
 .data-export-field input, .data-export-field select {
-    max-width: 55%;
+    width: 55%;
     float: right;
 }
 .data-export-results, .data-export-download, .data-export-cancel, .data-export-delete {

--- a/problem_builder/public/css/instructor_tool.css
+++ b/problem_builder/public/css/instructor_tool.css
@@ -25,6 +25,12 @@
     display: table-cell;
     padding-left: 1em;
 }
+.data-export-field-container {
+    min-width: 45%;
+}
+.data-export-options .data-export-actions {
+    max-width: 10%;
+}
 .data-export-field {
     margin-top: .5em;
     margin-bottom: .5em;
@@ -34,7 +40,7 @@
     vertical-align: middle;
 }
 .data-export-field input, .data-export-field select {
-    max-width: 60%;
+    max-width: 55%;
     float: right;
 }
 .data-export-results, .data-export-download, .data-export-cancel, .data-export-delete {

--- a/problem_builder/public/js/instructor_tool.js
+++ b/problem_builder/public/js/instructor_tool.js
@@ -170,7 +170,7 @@ function InstructorToolBlock(runtime, element) {
     var $downloadButton = $element.find('.data-export-download');
     var $deleteButton = $element.find('.data-export-delete');
     var $blockTypes = $element.find("select[name='block_types']");
-    var $rootBlockId = $element.find("input[name='root_block_id']");
+    var $rootBlockId = $element.find("select[name='root_block_id']");
     var $username = $element.find("input[name='username']");
     var $matchString = $element.find("input[name='match_string']");
     var $resultTable = $element.find('.data-export-results');

--- a/problem_builder/public/js/instructor_tool.js
+++ b/problem_builder/public/js/instructor_tool.js
@@ -4,6 +4,12 @@ function InstructorToolBlock(runtime, element) {
 
     // Pagination
 
+    $(document).ajaxSend(function(event, jqxhr, options) {
+        if (options.url.indexOf('get_result_page') !== -1) {
+            options.data = JSON.stringify(options.data);
+        }
+    });
+
     var Result = Backbone.Model.extend({
 
         initialize: function(attrs, options) {
@@ -41,10 +47,7 @@ function InstructorToolBlock(runtime, element) {
             reset: true,
             type: 'POST',
             contentType: 'application/json',
-            processData: false,
-            beforeSend: function(jqXHR, options) {
-                options.data = JSON.stringify(options.data);
-            }
+            processData: false
         },
 
         getFirstPage: function() {

--- a/problem_builder/public/js/instructor_tool.js
+++ b/problem_builder/public/js/instructor_tool.js
@@ -87,6 +87,8 @@ function InstructorToolBlock(runtime, element) {
             this._insertRecords();
             this._updateControls();
             this.$('#total-pages').text(this.collection.getTotalPages() || 0);
+            $('.data-export-status', $element).empty();
+            this.$el.show(700);
             return this;
         },
 
@@ -225,7 +227,6 @@ function InstructorToolBlock(runtime, element) {
     function updateView() {
         var $exportInfo = $('.data-export-info', $element),
             $statusArea = $('.data-export-status', $element), startTime;
-        $statusArea.empty();
         $exportInfo.empty();
         $startButton.toggle(!status.export_pending).prop('disabled', false);
         $cancelButton.toggle(status.export_pending).prop('disabled', false);
@@ -255,10 +256,7 @@ function InstructorToolBlock(runtime, element) {
                         }
                     )
                 ));
-
                 resultsView.collection.getFirstPage();
-
-                showResults();
             }
         } else {
             if (status.export_pending) {

--- a/problem_builder/tasks.py
+++ b/problem_builder/tasks.py
@@ -6,7 +6,6 @@ import time
 from celery.task import task
 from celery.utils.log import get_task_logger
 from instructor_task.models import ReportStore
-from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from student.models import user_by_anonymous_id
 from xmodule.modulestore.django import modulestore
@@ -31,9 +30,7 @@ def export_data(course_id, source_block_id_str, block_types, user_id, match_stri
     try:
         course_key = CourseKey.from_string(course_id)
         src_block = modulestore().get_items(course_key, qualifiers={'name': source_block_id_str}, depth=0)[0]
-        if src_block is None:
-            raise InvalidKeyError
-    except InvalidKeyError:
+    except IndexError:
         raise ValueError("Could not find the specified Block ID.")
     course_key_str = unicode(course_key)
 

--- a/problem_builder/tasks.py
+++ b/problem_builder/tasks.py
@@ -20,7 +20,7 @@ logger = get_task_logger(__name__)
 
 
 @task()
-def export_data(course_id, source_block_id_str, block_types, user_id, match_string, get_root=True):
+def export_data(course_id, source_block_id_str, block_types, user_id, match_string):
     """
     Exports student answers to all MCQ questions to a CSV file.
     """
@@ -33,12 +33,6 @@ def export_data(course_id, source_block_id_str, block_types, user_id, match_stri
     except IndexError:
         raise ValueError("Could not find the specified Block ID.")
     course_key_str = unicode(course_key)
-
-    root = src_block
-    if get_root:
-        # Get the root block for the course.
-        while root.parent:
-            root = root.get_parent()
 
     type_map = {cls.__name__: cls for cls in [MCQBlock, RatingBlock, AnswerBlock]}
 
@@ -62,7 +56,7 @@ def export_data(course_id, source_block_id_str, block_types, user_id, match_stri
                     # Blocks may refer to missing children. Don't break in this case.
                     pass
 
-    scan_for_blocks(root)
+    scan_for_blocks(src_block)
 
     # Define the header row of our CSV:
     rows = []

--- a/problem_builder/tasks.py
+++ b/problem_builder/tasks.py
@@ -149,6 +149,8 @@ def _get_submissions(course_key_str, block, user_id):
     # Note this requires one giant query that retrieves all student submissions for `block` at once.
     block_id = unicode(block.scope_ids.usage_id.replace(branch=None, version_guid=None))
     block_type = _get_type(block)
+    if block_type == 'pb-answer':
+        block_id = block.name  # item_id of Long Answer submission matches question ID and not block ID
     if not user_id:
         return sub_api.get_all_submissions(course_key_str, block_id, block_type)
     else:

--- a/problem_builder/tasks.py
+++ b/problem_builder/tasks.py
@@ -97,7 +97,7 @@ def _extract_data(course_key_str, block, user_id, match_string):
     block_type = _get_type(block)
 
     # Extract info for "Question" column
-    block_question = block.question
+    block_question = _get_question(block)
 
     # Extract info for "Answer" and "Username" columns
     # - Get all of the most recent student submissions for this block:
@@ -139,6 +139,13 @@ def _get_type(block):
     Return type of `block`.
     """
     return block.scope_ids.block_type
+
+
+def _get_question(block):
+    """
+    Return question for `block`; default to question ID if `question` is not set.
+    """
+    return block.question or block.name
 
 
 def _get_submissions(course_key_str, block, user_id):

--- a/problem_builder/templates/html/instructor_tool.html
+++ b/problem_builder/templates/html/instructor_tool.html
@@ -27,8 +27,16 @@
     <div class="data-export-field-container">
       <div class="data-export-field">
         <label>
-          <span>{% trans "Root block ID:" %}</span>
-          <input type="text" name="root_block_id" />
+          <span>{% trans "Section/Question:" %}</span>
+          <select name="root_block_id">
+            {% for block in block_tree %}
+            <option value="{{ block.id }}"
+                    {% if not block.eligible %} disabled="disabled" {% endif %}>
+              {% for _ in ""|ljust:block.depth %}&nbsp;&nbsp;{% endfor %}
+              {{ block.name }}
+            </option>
+            {% endfor %}
+          </select>
         </label>
       </div>
     </div>

--- a/problem_builder/tests/integration/test_instructor_tool.py
+++ b/problem_builder/tests/integration/test_instructor_tool.py
@@ -62,6 +62,36 @@ class InstructorToolTest(SeleniumXBlockTest):
         'instructor_task.models': MockInstructorTaskModelsModule(),
     })
     @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
+    def test_data_export_delete(self):
+        instructor_tool = self.go_to_view()
+        start_button = instructor_tool.find_element_by_class_name('data-export-start')
+        result_block = instructor_tool.find_element_by_class_name('data-export-results')
+        status_area = instructor_tool.find_element_by_class_name('data-export-status')
+        download_button = instructor_tool.find_element_by_class_name('data-export-download')
+        cancel_button = instructor_tool.find_element_by_class_name('data-export-cancel')
+        delete_button = instructor_tool.find_element_by_class_name('data-export-delete')
+
+        start_button.click()
+
+        self.wait_until_visible(result_block)
+        self.wait_until_visible(delete_button)
+
+        delete_button.click()
+
+        self.wait_until_hidden(result_block)
+        self.wait_until_hidden(delete_button)
+
+        self.assertTrue(start_button.is_enabled())
+        self.assertEqual('', status_area.text)
+        self.assertFalse(download_button.is_displayed())
+        self.assertFalse(cancel_button.is_displayed())
+
+    @patch.dict('sys.modules', {
+        'problem_builder.tasks': MockTasksModule(successful=True),
+        'instructor_task': True,
+        'instructor_task.models': MockInstructorTaskModelsModule(),
+    })
+    @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
     def test_data_export_success(self):
         instructor_tool = self.go_to_view()
         start_button = instructor_tool.find_element_by_class_name('data-export-start')

--- a/problem_builder/tests/integration/test_instructor_tool.py
+++ b/problem_builder/tests/integration/test_instructor_tool.py
@@ -7,7 +7,7 @@ from mock import patch, Mock
 from selenium.common.exceptions import NoSuchElementException
 from xblockutils.base_test import SeleniumXBlockTest
 
-from problem_builder.instructor_tool import InstructorToolBlock
+from problem_builder.instructor_tool import PAGE_SIZE, InstructorToolBlock
 
 
 class MockTasksModule(object):
@@ -199,7 +199,7 @@ class InstructorToolTest(SeleniumXBlockTest):
             successful=True, display_data=[[
                 'Test section', 'Test subsection', 'Test unit',
                 'Test type', 'Test question', 'Test answer', 'Test username'
-            ] for _ in range(45)]),
+            ] for _ in range(PAGE_SIZE*3)]),
         'instructor_task': True,
         'instructor_task.models': MockInstructorTaskModelsModule(),
     })
@@ -224,7 +224,7 @@ class InstructorToolTest(SeleniumXBlockTest):
                 'Test type', 'Test question', 'Test answer', 'Test username'
         ]:
             occurrences = re.findall(contents, result_block.text)
-            self.assertEqual(len(occurrences), 15)
+            self.assertEqual(len(occurrences), PAGE_SIZE)
 
         self.assertFalse(first_page_button.is_enabled())
         self.assertFalse(prev_page_button.is_enabled())

--- a/problem_builder/tests/integration/test_instructor_tool.py
+++ b/problem_builder/tests/integration/test_instructor_tool.py
@@ -146,6 +146,7 @@ class InstructorToolTest(SeleniumXBlockTest):
         start_button.click()
 
         self.wait_until_visible(result_block)
+        time.sleep(1)  # Allow some time for result block to fully fade in
 
         self.assertFalse(first_page_button.is_enabled())
         self.assertFalse(prev_page_button.is_enabled())
@@ -179,6 +180,7 @@ class InstructorToolTest(SeleniumXBlockTest):
         start_button.click()
 
         self.wait_until_visible(result_block)
+        time.sleep(1)  # Allow some time for result block to fully fade in
 
         for contents in [
                 'Test section', 'Test subsection', 'Test unit',
@@ -218,6 +220,7 @@ class InstructorToolTest(SeleniumXBlockTest):
         start_button.click()
 
         self.wait_until_visible(result_block)
+        time.sleep(1)  # Allow some time for result block to fully fade in
 
         for contents in [
                 'Test section', 'Test subsection', 'Test unit',


### PR DESCRIPTION
This PR improves UX for the "Instructor Tool" XBlock by introducing a dropdown menu for constraining the set of exported answers to a specific block in the course outline:

![Instructor Tool with dropdown](https://cloud.githubusercontent.com/assets/961441/8734274/3c316eda-2c09-11e5-8ecc-e146e317f0a8.png)

It also enables client-server communication for pagination functionality introduced in #45. This means that instead of transferring all results to the client when the export process finishes and paginating them there, at most `PAGE_SIZE` items (currently: 15) are transferred at a time. This is not a user-facing change (except for the fact that navigating between result pages takes a little bit longer now that the client has to communicate with the server to obtain more data).

### Testing

From Studio:

1. Add `pb-instructor-tool` to advanced modules.
2. Add one or more MCQs/rating questions/long answer blocks to a unit.
3. Add an instructor tool block to the same or another unit.

From the LMS:

1. Provide answers to MCQ/rating questions/long answers blocks.
2. Switch to instructor tool and select a block from the "Section/Question" dropdown.
3. Click "Search".
4. Repeat for other blocks.
5. **Optional**: For each result set, use pagination controls to navigate between result pages.