### PR TITLE
Fix JS bug when HTML block is followed by an answer block

### DIFF
--- a/problem_builder/public/js/mentoring.js
+++ b/problem_builder/public/js/mentoring.js
@@ -107,7 +107,7 @@ function MentoringBlock(runtime, element) {
     function getChildByName(name) {
         for (var i = 0; i < children.length; i++) {
             var child = children[i];
-            if (child && child.name.toString() === name) {
+            if (child && typeof child.name !== 'undefined' && child.name.toString() === name) {
                 return child;
             }
         }


### PR DESCRIPTION
This fixes a JS error that would occur when a PB block contains an HTML child followed by an answer block: `TypeError: Cannot read property 'toString' of undefined`

The reason for the error is that HTML blocks don't have a `name` property. This fix is simple. Unfortunately I couldn't figure out how to add a regression test for this, since the workbench runtime doesn't appear to have this bug - only the edx-platform runtime.

**Sandbox** URL that previously had the issue: http://sandbox2.opencraft.com/courses/course-v1:HGSE+1x+2015/courseware/Week_1_Welcome_and_orientation/Change_Diary_Using_the_Change_Diary/