### PR TITLE
Allow toggling show_title behaviour during upgrade (OC-805)

### DIFF
--- a/problem_builder/v1/tests/test_upgrade.py
+++ b/problem_builder/v1/tests/test_upgrade.py
@@ -23,7 +23,7 @@ Test that we can upgrade from mentoring v1 to problem builder (v2).
 import ddt
 from lxml import etree
 from problem_builder import MentoringBlock
-from problem_builder.v1.xml_changes import convert_xml_v1_to_v2
+from problem_builder.v1.xml_changes import convert_xml_to_v2
 import os.path
 from StringIO import StringIO
 import unittest
@@ -66,7 +66,7 @@ class TestUpgrade(unittest.TestCase):
 
         parser = etree.XMLParser(remove_blank_text=True)
         xml_root = etree.parse(StringIO(old_block.xml_content), parser=parser).getroot()
-        convert_xml_v1_to_v2(xml_root)
+        convert_xml_to_v2(xml_root)
         converted_block = self.create_block_from_node(xml_root)
 
         with open("{}/{}_new.xml".format(xml_path, file_name)) as xmlfile:


### PR DESCRIPTION
JIRA: OC-805

It was discovered that when migrating from [the old gsehub version of xblock-mentoring](https://github.com/edx/edx-platform/blob/4b4ce5f1226a49840/requirements/edx/edx-private.txt#L4), "Question" titles get added to every question even though they were never an option in that version. When migrating from the edx-solutions version, "Question" titles are added because they are the default in that version.

I have added a new option to the migration script that allows the user to toggle "v0" upgrade, which will set "show_title" to False by default on each answer/mcq/etc. We cannot change the behavior in general, because titles are shown by default in the most recent versions of xblock-mentoring v1.

Example usage:
```
SERVICE_VARIANT=cms \
  DJANGO_SETTINGS_MODULE="cms.envs.devstack" \
  python -m problem_builder.v1.upgrade \
  "course-v1:HGSE+1x+2015" --version=v0
```

Default behavior (without the `--version=v0` flag):
![screen shot 2015-07-24 at 1 14 43 pm](https://cloud.githubusercontent.com/assets/945577/8883745/09cd2742-3206-11e5-94e9-af0645e53bdc.png)

New behavior (with the `--version=v0` flag):
![screen shot 2015-07-24 at 1 14 53 pm](https://cloud.githubusercontent.com/assets/945577/8883749/169424ee-3206-11e5-83b5-5a83ea36c487.png)
