### PR TITLE
Add an extra selector to fix CSS rule ambiguity

### DIFF
--- a/problem_builder/public/themes/lms.css
+++ b/problem_builder/public/themes/lms.css
@@ -31,7 +31,7 @@ div.course-wrapper section.course-content .themed-xblock.mentoring p:empty {
     margin-bottom: 1.41575em;
 }
 
-.themed-xblock.mentoring .choices-list {
+.themed-xblock.mentoring .questionnaire .choices-list {
     display: table;
     width: 100%;
     border-spacing: 0;
@@ -54,7 +54,7 @@ div.course-wrapper section.course-content .themed-xblock.mentoring p:empty {
     vertical-align: top;
 }
 
-.themed-xblock.mentoring .choice-tips {
+.themed-xblock.mentoring .choice-tips-container .choice-tips {
     position: relative;
 }
 


### PR DESCRIPTION
JIRA: OC-839

On the Harvard GSE instance, Problem Builder's LMS theme was not rendering correctly. The issue turned out to be that some of the theme's CSS rules had the same specificity as the "unthemed" rules, so that which one would be used was ambiguous.

Screenshot showing [desired interpretation](https://cloud.githubusercontent.com/assets/945577/8925664/6188fa46-34be-11e5-91eb-b3ac7bd19f0f.png) and [valid but wrong interpretation](https://cloud.githubusercontent.com/assets/945577/8925665/6bf3de38-34be-11e5-998e-e3642589572b.png).

Fix was to add an extra CSS selector to each of the rules in question. 