### PR TITLE
Don't cause a 500 error in the LMS if get_block unexpectedly returns None

### DIFF
--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -236,7 +236,9 @@ class MentoringBlock(XBlock, StepParentMixin, StudioEditableXBlockMixin, StudioC
 
         for child_id in self.children:
             child = self.runtime.get_block(child_id)
-            if not isinstance(child, MentoringMessageBlock):
+            if child is None:  # child should not be None but it can happen due to bugs or permission issues
+                child_content += u"<p>[{}]</p>".format(self._(u"Error: Unable to load child component."))
+            elif not isinstance(child, MentoringMessageBlock):
                 try:
                     if self.is_assessment and isinstance(child, StepMixin):
                         child_fragment = child.render('assessment_step_view', context)

--- a/problem_builder/tests/integration/test_progression.py
+++ b/problem_builder/tests/integration/test_progression.py
@@ -19,7 +19,6 @@
 #
 
 # Imports ###########################################################
-
 from .base_test import MentoringBaseTest
 
 
@@ -34,8 +33,10 @@ class MentoringProgressionTest(MentoringBaseTest):
         """
         self.assertEqual(warning_dom.text, 'You need to complete the previous step before attempting this step.')
         warning_link = warning_dom.find_element_by_xpath('./*')
-        link_href = 'http://localhost:8081{}'.format(link_href)
-        self.assertEqual(warning_link.get_attribute('href'), link_href)
+        self.assertTrue(
+            warning_link.get_attribute('href').endswith(link_href),
+            "expected link href '{}' to end with '{}'".format(warning_link.get_attribute('href'), link_href)
+        )
 
     def assert_warning_is_hidden(self, mentoring):
         for elem in mentoring.find_elements_by_css_selector('.warning'):

--- a/problem_builder/tests/unit/test_mentoring.py
+++ b/problem_builder/tests/unit/test_mentoring.py
@@ -31,6 +31,20 @@ class TestMentoringBlock(unittest.TestCase):
 
             self.assertFalse(patched_runtime.publish.called)
 
+    def test_does_not_crash_when_get_child_is_broken(self):
+        block = MentoringBlock(MagicMock(), DictFieldData({
+            'children': ['invalid_id'],
+        }), Mock())
+
+        with patch.object(block, 'runtime') as patched_runtime:
+            patched_runtime.publish = Mock()
+            patched_runtime.service().ugettext = lambda str: str
+            patched_runtime.get_block = lambda block_id: None
+
+            fragment = block.student_view(context={})
+
+            self.assertIn('Unable to load child component', fragment.content)
+
 
 @ddt.ddt
 class TestMentoringBlockTheming(unittest.TestCase):


### PR DESCRIPTION
**Description**: We ran into [a weird issue](PLAT-772) in a live course, where `get_block` returned `None` in the following code:

```python
for child_id in self.children:
    child = self.runtime.get_block(child_id)
```
Since we didn't expect `child` ever to be `None` with that API, this resulted in `AttributeError: 'NoneType' object has no attribute 'render'`, causing the whole subsection of the LMS to be replaced with a 500 error.

Although `get_block` *shouldn't* return `None` if everything is working, it is an expected return value when an error occurs, so we should be able to handle it gracefully.

I added an error message to the rendered HTML so that there will at least be some indication that content is missing - otherwise this could result in content silently disappearing for students even though instructors can see it fine :-/

**Merge deadline**: ASAP, targeting this week's release

**Reviewers**: @smarnach 

attn: @antoviaque 