### PR TITLE
Instructor Tool: Support searching for answers from multiple users

### DIFF
--- a/problem_builder/public/js/instructor_tool.js
+++ b/problem_builder/public/js/instructor_tool.js
@@ -225,7 +225,7 @@ function InstructorToolBlock(runtime, element) {
     var $deleteButton = $element.find('.data-export-delete');
     var $blockTypes = $element.find("select[name='block_types']");
     var $rootBlockId = $element.find("select[name='root_block_id']");
-    var $username = $element.find("input[name='username']");
+    var $usernames = $element.find("input[name='usernames']");
     var $matchString = $element.find("input[name='match_string']");
     var $resultTable = $element.find('.data-export-results');
 
@@ -335,7 +335,7 @@ function InstructorToolBlock(runtime, element) {
                 data = {
                     block_types: $blockTypes.val(),
                     root_block_id: $rootBlockId.val(),
-                    username: $username.val(),
+                    usernames: $usernames.val(),
                     match_string: $matchString.val()
                 };
                 data = JSON.stringify(data);

--- a/problem_builder/tasks.py
+++ b/problem_builder/tasks.py
@@ -20,7 +20,7 @@ logger = get_task_logger(__name__)
 
 
 @task()
-def export_data(course_id, source_block_id_str, block_types, user_id, match_string):
+def export_data(course_id, source_block_id_str, block_types, user_ids, match_string):
     """
     Exports student answers to all MCQ questions to a CSV file.
     """
@@ -64,8 +64,13 @@ def export_data(course_id, source_block_id_str, block_types, user_id, match_stri
 
     # Collect results for each block in blocks_to_include
     for block in blocks_to_include:
-        results = _extract_data(course_key_str, block, user_id, match_string)
-        rows += results
+        if not user_ids:
+            results = _extract_data(course_key_str, block, None, match_string)
+            rows += results
+        else:
+            for user_id in user_ids:
+                results = _extract_data(course_key_str, block, user_id, match_string)
+                rows += results
 
     # Generate the CSV:
     filename = u"pb-data-export-{}.csv".format(time.strftime("%Y-%m-%d-%H%M%S", time.gmtime(start_timestamp)))

--- a/problem_builder/templates/html/instructor_tool.html
+++ b/problem_builder/templates/html/instructor_tool.html
@@ -9,8 +9,8 @@
     <div class="data-export-field-container">
       <div class="data-export-field">
         <label>
-          <span>{% trans "Username:" %}</span>
-          <input type="text" name="username" />
+          <span>{% trans "Username[s]:" %}</span>
+          <input type="text" name="usernames" title="Enter one or more usernames, comma separated." />
         </label>
       </div>
     </div>


### PR DESCRIPTION
This PR extends existing functionality of the instructor tool by allowing users to enter multiple usernames to search for answers from multiple users simultaneously.

The input field for entering usernames expects usernames to be separated by commas, but is not sensitive to whitespace (meaning that commas can be surrounded by arbitrary amounts of whitespace).

#### Testing

From Studio:

1. Add `pb-instructor-tool` to advanced modules.
2. Add one or more MCQs/rating questions/long answer blocks to a unit.
3. Add an instructor tool block to the same or another unit.

From the LMS:

1. Sign in as `staff` and provide answers to some of the MCQ/rating questions/long answers blocks.
2. Repeat previous step for `honor`, `audit`, etc.
3. Sign in as `staff` and switch to instructor tool. Enter usernames of one or more users and click "Search". Observe that results include answers provided by users specified in the input field.
4. Repeat previous step for other combinations of usernames.
