### PR TITLE
Fix: Translate links in table column headers

### DIFF
--- a/problem_builder/table.py
+++ b/problem_builder/table.py
@@ -113,7 +113,11 @@ class MentoringTableBlock(
         for child_id in self.children:
             child = self.runtime.get_block(child_id)
             # Child should be an instance of MentoringTableColumn
-            header_values.append(child.header)
+            header = child.header
+            # Make sure /jump_to_id/ URLs are expanded correctly
+            if getattr(self.runtime, 'replace_jump_to_id_urls', None):
+                header = self.runtime.replace_jump_to_id_urls(header)
+            header_values.append(header)
             child_frag = child.render('mentoring_view', context)
             content_values.append(child_frag.content)
         context['header_values'] = header_values if any(header_values) else None

--- a/problem_builder/tests/integration/test_table.py
+++ b/problem_builder/tests/integration/test_table.py
@@ -20,6 +20,8 @@
 
 # Imports ###########################################################
 
+from mock import patch
+from workbench.runtime import WorkbenchRuntime
 from .base_test import MentoringBaseTest
 
 
@@ -54,3 +56,16 @@ class MentoringTableBlockTest(MentoringBaseTest):
         self.assertEqual(len(rows), 2)
         self.assertEqual(rows[0].text, 'This is the answer #1')
         self.assertEqual(rows[1].text, 'This is the answer #2')
+
+        # Ensure that table block makes an effort to translate URLs in column headers
+        link_template = "<a href='http://www.test.com'>{}</a> in a column header."
+        original_contents = link_template.format('Link')
+        updated_contents = link_template.format('Updated link')
+
+        with patch.object(WorkbenchRuntime, 'replace_jump_to_id_urls', create=True) as patched_method:
+            patched_method.return_value = updated_contents
+
+            table = self.go_to_page('Table 3', css_selector='.mentoring-table')
+            patched_method.assert_called_once_with(original_contents)
+            link = table.find_element_by_css_selector('a')
+            self.assertEquals(link.text, 'Updated link')

--- a/problem_builder/tests/integration/xml/table_3.xml
+++ b/problem_builder/tests/integration/xml/table_3.xml
@@ -1,0 +1,9 @@
+<vertical_demo>
+  <problem-builder display_submit="false" enforce_dependency="false">
+    <pb-table>
+      <pb-column header="&lt;a href='http://www.test.com'&gt;Link&lt;/a&gt; in a column header.">
+        <pb-answer-recap name="table_3_answer_1"/>
+      </pb-column>
+    </pb-table>
+  </problem-builder>
+</vertical_demo>


### PR DESCRIPTION
In the LMS, links of the form `/jump_to_id/<unit identifier>` are currently not translated/expanded correctly when they are part of a table column header. For example,

    /jump_to_id/mentoring_reflecting_on_feedback

correctly expands to

    https://openedx.gse.harvard.edu/courses/course-v1:HGSE+IOCEX+2015_T1/jump_to_id/mentoring_reflecting_on_feedback

when added to an HTML block. But when added to the column header of an Answer Recap table the expanded URL ends up missing information about the parent course (leading to an invalid link):

    https://openedx.gse.harvard.edu/jump_to_id/mentoring_reflecting_on_feedback

This PR adds code that makes sure links to course units that are part of table column headers are expanded correctly inside the LMS.

**Testing**

1. Download a copy of the [`course-v1:HGSE+IOCEX+2015_T1` course](https://studio.openedx.gse.harvard.edu/course/course-v1:HGSE+IOCEX+2015_T1) from the Harvard instance and import it into your local devstack.
2. In the LMS, navigate to Courseware ⟶ Change Diary ⟶ Change Diary: Map and Fields and make sure you are viewing the second unit ("My Change Diary - Maps").
3. Verify that the links in the table column headers can be used to successfully navigate to the corresponding units of the course.