### PR TITLE
Assessment targeted review

### DIFF
--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -424,7 +424,7 @@ class MentoringBlock(XBlock, StepParentMixin, StudioEditableXBlockMixin, StudioC
         Get the message to display to a student following a submission in assessment mode.
         """
         if not self.max_attempts_reached:
-            return self.get_message_content('on-assessment-review')
+            return self.get_message_content('on-assessment-review', or_default=True)
         else:
             return None
 
@@ -712,12 +712,16 @@ class MentoringBlock(XBlock, StepParentMixin, StudioEditableXBlockMixin, StudioC
     def max_attempts_reached(self):
         return self.max_attempts > 0 and self.num_attempts >= self.max_attempts
 
-    def get_message_content(self, message_type):
+    def get_message_content(self, message_type, or_default=False):
         for child_id in self.children:
             if child_isinstance(self, child_id, MentoringMessageBlock):
                 child = self.runtime.get_block(child_id)
                 if child.type == message_type:
                     return child.content
+        if or_default:
+            # Return the default value since no custom message is set.
+            # Note the WYSIWYG editor usually wraps the .content HTML in a <p> tag so we do the same here.
+            return '<p>{}</p>'.format(MentoringMessageBlock.MESSAGE_TYPES[message_type]['default'])
 
     def validate(self):
         """

--- a/problem_builder/message.py
+++ b/problem_builder/message.py
@@ -75,7 +75,8 @@ class MentoringMessageBlock(XBlock, StudioEditableXBlockMixin):
             "display_name": _(u"Review with attempts left"),
             "long_display_name": _(u"Message shown during review when attempts remain"),
             "default": _(
-                u"You may try this assessment again, and only the latest score will be used."
+                u"Note: if you retake this assessment, only your final score counts. "
+                "If you would like to keep this score, please continue to the next unit."
             ),
             "description": _(
                 u"In assessment mode, this message will be shown when the student is reviewing "

--- a/problem_builder/message.py
+++ b/problem_builder/message.py
@@ -84,6 +84,20 @@ class MentoringMessageBlock(XBlock, StudioEditableXBlockMixin):
                 "used up all of their allowed attempts."
             ),
         },
+        "on-assessment-review-question": {
+            "display_name": _(u"Study tips if this question was wrong"),
+            "long_display_name": _(u"Study tips shown during assessment review if wrong"),
+            "default": _(
+                u"Review ____."
+            ),
+            "description": _(
+                u"In assessment mode, this message will be shown when the student is reviewing "
+                "their answers to the assessment, if the student got this specific question "
+                "wrong and is allowed to try again. "
+                "This message is ignored in standard mode and is not shown if the student has "
+                "used up all of their allowed attempts."
+            ),
+        },
     }
 
     content = String(
@@ -103,6 +117,10 @@ class MentoringMessageBlock(XBlock, StudioEditableXBlockMixin):
             {"value": "incomplete", "display_name": MESSAGE_TYPES["incomplete"]["display_name"]},
             {"value": "max_attempts_reached", "display_name": MESSAGE_TYPES["max_attempts_reached"]["display_name"]},
             {"value": "on-assessment-review", "display_name": MESSAGE_TYPES["on-assessment-review"]["display_name"]},
+            {
+                "value": "on-assessment-review-question",
+                "display_name": MESSAGE_TYPES["on-assessment-review-question"]["display_name"]
+            },
         ),
     )
     editable_fields = ("content", )

--- a/problem_builder/public/css/problem-builder.css
+++ b/problem_builder/public/css/problem-builder.css
@@ -174,6 +174,17 @@
     display: none;
 }
 
+.mentoring .assessment-messages p.review-tips-intro {
+    margin-top: 1em;
+    margin-bottom: 0;
+    font-weight: bold;
+}
+
+.mentoring .assessment-messages .review-tips-list {
+    margin-top: 0;
+    padding-top: 0;
+}
+
 .pb-clarification span.clarification i {
     font-style: normal;
 }

--- a/problem_builder/public/css/problem-builder.css
+++ b/problem_builder/public/css/problem-builder.css
@@ -2,13 +2,11 @@
     margin: 1em 0em;
 }
 
-.mentoring .messages,
-.mentoring .assessment-messages {
+.mentoring .messages {
     display: none;
 }
 
-.mentoring .messages .title1,
-.mentoring .assessment-messages .title1 {
+.mentoring .messages .title1 {
     color: #333333;
     text-transform: uppercase;
     font-weight: bold;

--- a/problem_builder/public/css/problem-builder.css
+++ b/problem_builder/public/css/problem-builder.css
@@ -174,16 +174,25 @@
     display: none;
 }
 
-.mentoring .assessment-messages p.review-tips-intro {
-    margin-top: 1em;
+.mentoring .assessment-review-tips p.review-tips-intro {
+    margin-top: 1.2em;
     margin-bottom: 0;
     font-weight: bold;
 }
 
-.mentoring .assessment-messages .review-tips-list {
+.mentoring .assessment-review-tips .review-tips-list {
     margin-top: 0;
     padding-top: 0;
 }
+.mentoring .assessment-review-tips .review-tips-list li {
+    margin-left: 0.5em;
+    padding-left: 0;
+}
+.mentoring .assessment-review-tips .review-tips-list li p {
+    display: inline;
+    margin: 0;
+}
+
 
 .pb-clarification span.clarification i {
     font-style: normal;

--- a/problem_builder/public/css/questionnaire-edit.css
+++ b/problem_builder/public/css/questionnaire-edit.css
@@ -5,6 +5,13 @@
   line-height: 30px;
 }
 
+.xblock .add-xblock-component .new-component .new-component-type .add-xblock-component-button.disabled,
+.xblock .add-xblock-component .new-component .new-component-type .add-xblock-component-button.disabled:hover {
+  background-color: #ccc;
+  border-color: #888;
+  cursor: default;
+}
+
 .xblock[data-block-type=pb-mcq] .submission-message-help p,
 .xblock[data-block-type=pb-mrq] .submission-message-help p,
 .xblock[data-block-type=pb-rating] .submission-message-help p {

--- a/problem_builder/public/css/questionnaire-edit.css
+++ b/problem_builder/public/css/questionnaire-edit.css
@@ -4,3 +4,13 @@
   height: 30px;
   line-height: 30px;
 }
+
+.xblock[data-block-type=pb-mcq] .submission-message-help p,
+.xblock[data-block-type=pb-mrq] .submission-message-help p,
+.xblock[data-block-type=pb-rating] .submission-message-help p {
+	border-top: 1px solid #ddd;
+	font-size: 0.85em;
+	font-style: italic;
+	margin-top: 1em;
+	padding-top: 0.3em;
+}

--- a/problem_builder/public/js/mentoring_assessment_view.js
+++ b/problem_builder/public/js/mentoring_assessment_view.js
@@ -1,6 +1,7 @@
 function MentoringAssessmentView(runtime, element, mentoring) {
     var gradeTemplate = _.template($('#xblock-grade-template').html());
-    var reviewQuestionsTemplate = _.template($('#xblock-review-questions-template').html());
+    var reviewQuestionsTemplate = _.template($('#xblock-review-questions-template').html()); // Detailed list of which questions the user got wrong
+    var reviewTipsTemplate = _.template($('#xblock-review-tips-template').html()); // Tips about specific questions the user got wrong
     var submitDOM, nextDOM, reviewDOM, tryAgainDOM, messagesDOM, reviewLinkDOM;
     var submitXHR;
     var checkmark;
@@ -63,8 +64,20 @@ function MentoringAssessmentView(runtime, element, mentoring) {
         }
 
         mentoring.renderAttempts();
-        if (data.assessment_message && (data.max_attempts === 0 || data.num_attempts < data.max_attempts)) {
-            mentoring.setContent(messagesDOM, data.assessment_message);
+        if (data.max_attempts === 0 || data.num_attempts < data.max_attempts) {
+            var messageHTML = '';
+            if (data.assessment_message) {
+                messageHTML += data.assessment_message; // Overall on-assessment-review message
+            }
+            if (data.assessment_review_tips.length > 0) {
+                messageHTML += reviewTipsTemplate({
+                    // on-assessment-review-question messages specific to questions the student got wrong:
+                    tips: data.assessment_review_tips
+                });
+            }
+            if (messageHTML.length > 0) {
+                mentoring.setContent(messagesDOM, messageHTML);
+            }
             messagesDOM.show();
         }
         $('a.question-link', element).click(reviewJump);

--- a/problem_builder/public/js/mentoring_assessment_view.js
+++ b/problem_builder/public/js/mentoring_assessment_view.js
@@ -2,7 +2,7 @@ function MentoringAssessmentView(runtime, element, mentoring) {
     var gradeTemplate = _.template($('#xblock-grade-template').html());
     var reviewQuestionsTemplate = _.template($('#xblock-review-questions-template').html()); // Detailed list of which questions the user got wrong
     var reviewTipsTemplate = _.template($('#xblock-review-tips-template').html()); // Tips about specific questions the user got wrong
-    var submitDOM, nextDOM, reviewDOM, tryAgainDOM, messagesDOM, reviewLinkDOM;
+    var submitDOM, nextDOM, reviewDOM, tryAgainDOM, messagesDOM, reviewLinkDOM, reviewTipsDOM;
     var submitXHR;
     var checkmark;
     var active_child;
@@ -24,6 +24,7 @@ function MentoringAssessmentView(runtime, element, mentoring) {
         $('.grade').html('');
         $('.attempts').html('');
         messagesDOM.empty().hide();
+        reviewTipsDOM.empty().hide();
     }
 
     function no_more_attempts() {
@@ -65,20 +66,18 @@ function MentoringAssessmentView(runtime, element, mentoring) {
 
         mentoring.renderAttempts();
         if (data.max_attempts === 0 || data.num_attempts < data.max_attempts) {
-            var messageHTML = '';
             if (data.assessment_message) {
-                messageHTML += data.assessment_message; // Overall on-assessment-review message
+                // Overall on-assessment-review message:
+                mentoring.setContent(messagesDOM, data.assessment_message);
+                messagesDOM.show();
             }
             if (data.assessment_review_tips.length > 0) {
-                messageHTML += reviewTipsTemplate({
-                    // on-assessment-review-question messages specific to questions the student got wrong:
+                // on-assessment-review-question messages specific to questions the student got wrong:
+                mentoring.setContent(reviewTipsDOM, reviewTipsTemplate({
                     tips: data.assessment_review_tips
-                });
+                }));
+                reviewTipsDOM.show();
             }
-            if (messageHTML.length > 0) {
-                mentoring.setContent(messagesDOM, messageHTML);
-            }
-            messagesDOM.show();
         }
         $('a.question-link', element).click(reviewJump);
     }
@@ -114,6 +113,7 @@ function MentoringAssessmentView(runtime, element, mentoring) {
         reviewLinkDOM = $(element).find('.review-link');
         checkmark = $('.assessment-checkmark', element);
         messagesDOM = $('.assessment-messages', element);
+        reviewTipsDOM = $('.assessment-review-tips', element);
 
         submitDOM.show();
         submitDOM.bind('click', submit);

--- a/problem_builder/public/js/mentoring_assessment_view.js
+++ b/problem_builder/public/js/mentoring_assessment_view.js
@@ -23,6 +23,7 @@ function MentoringAssessmentView(runtime, element, mentoring) {
 
         $('.grade').html('');
         $('.attempts').html('');
+        assessmentMessageDOM.html('');
         reviewTipsDOM.empty().hide();
     }
 

--- a/problem_builder/public/js/mentoring_assessment_view.js
+++ b/problem_builder/public/js/mentoring_assessment_view.js
@@ -2,7 +2,7 @@ function MentoringAssessmentView(runtime, element, mentoring) {
     var gradeTemplate = _.template($('#xblock-grade-template').html());
     var reviewQuestionsTemplate = _.template($('#xblock-review-questions-template').html()); // Detailed list of which questions the user got wrong
     var reviewTipsTemplate = _.template($('#xblock-review-tips-template').html()); // Tips about specific questions the user got wrong
-    var submitDOM, nextDOM, reviewDOM, tryAgainDOM, messagesDOM, reviewLinkDOM, reviewTipsDOM;
+    var submitDOM, nextDOM, reviewDOM, tryAgainDOM, assessmentMessageDOM, reviewLinkDOM, reviewTipsDOM;
     var submitXHR;
     var checkmark;
     var active_child;
@@ -23,7 +23,6 @@ function MentoringAssessmentView(runtime, element, mentoring) {
 
         $('.grade').html('');
         $('.attempts').html('');
-        messagesDOM.empty().hide();
         reviewTipsDOM.empty().hide();
     }
 
@@ -68,16 +67,18 @@ function MentoringAssessmentView(runtime, element, mentoring) {
         if (data.max_attempts === 0 || data.num_attempts < data.max_attempts) {
             if (data.assessment_message) {
                 // Overall on-assessment-review message:
-                mentoring.setContent(messagesDOM, data.assessment_message);
-                messagesDOM.show();
+                assessmentMessageDOM.html(data.assessment_message);
             }
             if (data.assessment_review_tips.length > 0) {
                 // on-assessment-review-question messages specific to questions the student got wrong:
-                mentoring.setContent(reviewTipsDOM, reviewTipsTemplate({
+                reviewTipsDOM.html(reviewTipsTemplate({
                     tips: data.assessment_review_tips
                 }));
                 reviewTipsDOM.show();
             }
+        } else {
+            var msg = gettext("Note: you have used all attempts. Continue to the next unit.");
+            assessmentMessageDOM.html('').append($('<p></p>').html(msg));
         }
         $('a.question-link', element).click(reviewJump);
     }
@@ -112,7 +113,7 @@ function MentoringAssessmentView(runtime, element, mentoring) {
         tryAgainDOM = $(element).find('.submit .input-try-again');
         reviewLinkDOM = $(element).find('.review-link');
         checkmark = $('.assessment-checkmark', element);
-        messagesDOM = $('.assessment-messages', element);
+        assessmentMessageDOM = $('.assessment-message', element);
         reviewTipsDOM = $('.assessment-review-tips', element);
 
         submitDOM.show();

--- a/problem_builder/public/js/questionnaire_edit.js
+++ b/problem_builder/public/js/questionnaire_edit.js
@@ -1,4 +1,0 @@
-function QuestionnaireEdit(runtime, element) {
-    'use strict';
-    ProblemBuilderUtil.transformClarifications(element);
-}

--- a/problem_builder/public/themes/apros.css
+++ b/problem_builder/public/themes/apros.css
@@ -16,3 +16,8 @@
 .mentoring h3 {
     text-transform: uppercase;
 }
+
+.themed-xblock.mentoring .assessment-review-tips .review-tips-list li {
+    margin-left: 1.8em;
+    padding-left: 0;
+}

--- a/problem_builder/questionnaire.py
+++ b/problem_builder/questionnaire.py
@@ -33,6 +33,7 @@ from xblockutils.studio_editable import StudioEditableXBlockMixin, StudioContain
 
 from .choice import ChoiceBlock
 from .mentoring import MentoringBlock
+from .message import MentoringMessageBlock
 from .step import StepMixin
 from .tip import TipBlock
 
@@ -226,3 +227,11 @@ class QuestionnaireAbstractBlock(StudioEditableXBlockMixin, StudioContainerXBloc
                 break
             values_with_tips.update(values)
         return validation
+
+    def get_review_tip(self):
+        """ Get the text to show on the assessment review when the student gets this question wrong """
+        for child_id in self.children:
+            if child_isinstance(self, child_id, MentoringMessageBlock):
+                child = self.runtime.get_block(child_id)
+                if child.type == "on-assessment-review-question":
+                    return child.content

--- a/problem_builder/questionnaire.py
+++ b/problem_builder/questionnaire.py
@@ -181,8 +181,8 @@ class QuestionnaireAbstractBlock(StudioEditableXBlockMixin, StudioContainerXBloc
         fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/problem-builder.css'))
         fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/questionnaire-edit.css'))
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/util.js'))
-        fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/questionnaire_edit.js'))
-        fragment.initialize_js('QuestionnaireEdit')
+        fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/mentoring_edit.js'))
+        fragment.initialize_js('MentoringEditComponents')
         return fragment
 
     def validate_field_data(self, validation, data):

--- a/problem_builder/step.py
+++ b/problem_builder/step.py
@@ -52,6 +52,12 @@ class StepParentMixin(object):
         """
         return [_normalize_id(child_id) for child_id in self.children if child_isinstance(self, child_id, StepMixin)]
 
+    def get_steps(self):
+        """ Get the step children of this block, cached if possible. """
+        if getattr(self, "_steps_cache", None) is None:
+            self._steps_cache = [self.runtime.get_block(child_id) for child_id in self.steps]
+        return self._steps_cache
+
 
 class StepMixin(object):
     """

--- a/problem_builder/step.py
+++ b/problem_builder/step.py
@@ -45,7 +45,7 @@ class StepParentMixin(object):
     An XBlock mixin for a parent block containing Step children
     """
 
-    @property
+    @lazy
     def steps(self):
         """
         Get the usage_ids of all of this XBlock's children that are "Steps"

--- a/problem_builder/templates/html/mentoring.html
+++ b/problem_builder/templates/html/mentoring.html
@@ -53,6 +53,7 @@
     </div>
     {% endif %}
     <div class="messages"></div>
+    <div class="assessment-review-tips"></div>
   </div>
   <div class="review-link"><a href="#">Review final grade</a></div>
 </div>

--- a/problem_builder/templates/html/mentoring.html
+++ b/problem_builder/templates/html/mentoring.html
@@ -16,6 +16,8 @@
   {% endif %}
 
   <div class="{{self.mode}}-question-block">
+    <div class="assessment-message"></div>
+
     {{child_content|safe}}
 
     {% if self.display_submit %}
@@ -33,8 +35,6 @@
          data-incorrect="{{ self.incorrect_json }}"
          data-partial="{{ self.partial_json }}">
     </div>
-
-    <div class="assessment-messages"></div>
 
     <div class="submit">
       {% if self.mode == 'assessment' %}

--- a/problem_builder/templates/html/mentoring.html
+++ b/problem_builder/templates/html/mentoring.html
@@ -28,6 +28,7 @@
          data-num_attempts="{{ self.num_attempts }}"
          data-extended_feedback="{%if self.extended_feedback %}True{% endif %}"
          data-assessment_message="{{ self.assessment_message }}"
+         data-assessment_review_tips="{{ self.review_tips_json }}"
          data-correct="{{ self.correct_json }}"
          data-incorrect="{{ self.incorrect_json }}"
          data-partial="{{ self.partial_json }}">

--- a/problem_builder/templates/html/mentoring_assessment_templates.html
+++ b/problem_builder/templates/html/mentoring_assessment_templates.html
@@ -1,10 +1,4 @@
 <script type="text/template" id="xblock-grade-template">
-  <% if (_.isNumber(max_attempts) && max_attempts > 0 && num_attempts >= max_attempts) {{ %>
-  <p><%= gettext("Note: you have used all attempts. Continue to the next unit.") %></p>
-  <% }} else {{ %>
-  <p><%= gettext("Note: if you retake this assessment, only your final score counts.") %></p>
-  <% }} %>
-
   <div class="grade-result">
     <h2>
       <%= _.template(gettext("You scored {percent}% on this assessment."), {percent: score}, {interpolate: /\{(.+?)\}/g}) %>

--- a/problem_builder/templates/html/mentoring_assessment_templates.html
+++ b/problem_builder/templates/html/mentoring_assessment_templates.html
@@ -56,3 +56,24 @@
     <hr/>
   </div>
 </script>
+
+<!-- Template for extended feedback: Show extended feedback details when all attempts are used up. -->
+<script type="text/template" id="xblock-review-questions-template">
+<% var q, last_question; %>
+<ul class="review-list <%= label %>-list">
+    <% for (var question in questions) {{ q = questions[question]; last_question = question == questions.length - 1; %>
+    <li><a href="#" class="question-link" data-step="<%= q.number %>"><%= _.template(gettext("Question {number}"), {number: q.number}, {interpolate: /\{(.+?)\}/g}) %></a></li>
+    <% }} %>
+</ul>
+</script>
+
+<!-- Tips about specific questions the student got wrong. From pb-message[type=on-assessment-review-question] blocks -->
+<script type="text/template" id="xblock-review-tips-template">
+<p class="review-tips-intro"><%= gettext("You might consider reviewing the following items before your next assessment attempt:") %></p>
+<ul class="review-tips-list">
+    <% for (var tip_idx in tips) {{ %>
+        <li><%= tips[tip_idx] %></li>
+    <% }} %>
+</ul>
+</script>
+

--- a/problem_builder/templates/html/mentoring_review_questions.html
+++ b/problem_builder/templates/html/mentoring_review_questions.html
@@ -1,8 +1,0 @@
-<script type="text/template" id="xblock-review-questions-template">
-<% var q, last_question; %>
-<ul class="review-list <%= label %>-list">
-    <% for (var question in questions) {{ q = questions[question]; last_question = question == questions.length - 1; %>
-    <li><a href="#" class="question-link" data-step="<%= q.number %>"><%= _.template(gettext("Question {number}"), {number: q.number}, {interpolate: /\{(.+?)\}/g}) %></a></li>
-    <% }} %>
-</ul>
-</script>

--- a/problem_builder/templates/html/questionnaire_add_buttons.html
+++ b/problem_builder/templates/html/questionnaire_add_buttons.html
@@ -5,6 +5,7 @@
     <ul class="new-component-type">
       <li><a href="#" class="single-template add-xblock-component-button" data-category="pb-choice" data-boilerplate="studio_default">{% trans "Add Custom Choice" %}</a></li>
       <li><a href="#" class="single-template add-xblock-component-button" data-category="pb-tip">{% trans "Add Tip" %}</a></li>
+      <li><a href="#" class="single-template add-xblock-component-button" data-category="pb-message" data-boilerplate="on-assessment-review-question">{% trans "Message (Assessment Review)" %}</a></li>
     </ul>
   </div>
 </div>

--- a/problem_builder/tests/integration/test_assessment.py
+++ b/problem_builder/tests/integration/test_assessment.py
@@ -394,15 +394,15 @@ class MentoringAssessmentTest(MentoringAssessmentBaseTest):
         self.multiple_response_question(4, mentoring, controls, ("Its beauty",), PARTIAL, last=True)
 
         # The review tips for MCQ 2 and the MRQ should be shown:
-        messages = mentoring.find_element_by_css_selector('.assessment-messages')
-        self.assertTrue(messages.is_displayed())
-        self.assertIn('You might consider reviewing the following items', messages.text)
-        self.assertIn('Take another look at', messages.text)
-        self.assertIn('Lesson 1', messages.text)
-        self.assertNotIn('Lesson 2', messages.text)  # This MCQ was correct
-        self.assertIn('Lesson 3', messages.text)
+        review_tips = mentoring.find_element_by_css_selector('.assessment-review-tips')
+        self.assertTrue(review_tips.is_displayed())
+        self.assertIn('You might consider reviewing the following items', review_tips.text)
+        self.assertIn('Take another look at', review_tips.text)
+        self.assertIn('Lesson 1', review_tips.text)
+        self.assertNotIn('Lesson 2', review_tips.text)  # This MCQ was correct
+        self.assertIn('Lesson 3', review_tips.text)
         # The on-assessment-review message is also shown if attempts remain:
-        self.assertIn('Assessment additional feedback message text', messages.text)
+        self.assert_messages_text(mentoring, "Assessment additional feedback message text")
 
         self.assert_clickable(controls.try_again)
         controls.try_again.click()
@@ -415,7 +415,7 @@ class MentoringAssessmentTest(MentoringAssessmentBaseTest):
         self.multiple_response_question(4, mentoring, controls, user_selection, CORRECT, last=True)
 
         self.assert_messages_text(mentoring, "Assessment additional feedback message text")
-        self.assertNotIn('You might consider reviewing the following items', messages.text)
+        self.assertFalse(review_tips.is_displayed())
 
         self.assert_clickable(controls.try_again)
         controls.try_again.click()
@@ -427,7 +427,7 @@ class MentoringAssessmentTest(MentoringAssessmentBaseTest):
         self.multiple_response_question(4, mentoring, controls, ("Its beauty",), PARTIAL, last=True)
 
         # The review tips will not be shown because no attempts remain:
-        self.assert_messages_empty(mentoring)
+        self.assertFalse(review_tips.is_displayed())
 
     def test_single_question_assessment(self):
         """

--- a/problem_builder/tests/integration/test_assessment.py
+++ b/problem_builder/tests/integration/test_assessment.py
@@ -350,6 +350,8 @@ class MentoringAssessmentTest(MentoringAssessmentBaseTest):
         self.assert_message_text(mentoring, "Assessment additional feedback message text")
         self.assert_clickable(controls.try_again)
         controls.try_again.click()
+
+        self.wait_until_hidden(controls.try_again)
         self.assert_no_message_text(mentoring)
 
         self.freeform_answer(

--- a/problem_builder/tests/integration/test_assessment.py
+++ b/problem_builder/tests/integration/test_assessment.py
@@ -281,6 +281,10 @@ class MentoringAssessmentTest(MentoringAssessmentBaseTest):
         self.assertEqual(message_wrapper.text, text)
         self.assertTrue(message_wrapper.is_displayed())
 
+    def assert_no_message_text(self, mentoring):
+        message_wrapper = mentoring.find_element_by_css_selector('.assessment-message')
+        self.assertEqual(message_wrapper.text, '')
+
     def extended_feedback_checks(self, mentoring, controls, expected_results):
         # Multiple choice is third correctly answered question
         self.assert_hidden(controls.review_link)
@@ -346,6 +350,7 @@ class MentoringAssessmentTest(MentoringAssessmentBaseTest):
         self.assert_message_text(mentoring, "Assessment additional feedback message text")
         self.assert_clickable(controls.try_again)
         controls.try_again.click()
+        self.assert_no_message_text(mentoring)
 
         self.freeform_answer(
             1, mentoring, controls, 'This is a different answer', CORRECT, saved_value='This is the answer'

--- a/problem_builder/tests/integration/xml_templates/assessment.xml
+++ b/problem_builder/tests/integration/xml_templates/assessment.xml
@@ -22,6 +22,11 @@
         <pb-tip values='["yes"]'>Great!</pb-tip>
         <pb-tip values='["maybenot"]'>Ah, damn.</pb-tip>
         <pb-tip values='["understand"]'><div id="test-custom-html">Really?</div></pb-tip>
+        {% if include_review_tips %}
+            <pb-message type="on-assessment-review-question">
+                <html>Take another look at <a href="#">Lesson 1</a></html>
+            </pb-message>
+        {% endif %}
     </pb-mcq>
 
     <pb-rating name="mcq_1_2" low="Not good at all" high="Extremely good" question="How much do you rate this MCQ?" correct_choices='["4","5"]'>
@@ -30,6 +35,11 @@
         <pb-tip values='["4","5"]'>I love good grades.</pb-tip>
         <pb-tip values='["1","2", "3"]'>Will do better next time...</pb-tip>
         <pb-tip values='["notwant"]'>Your loss!</pb-tip>
+        {% if include_review_tips %}
+            <pb-message type="on-assessment-review-question">
+                <html>Take another look at <a href="#">Lesson 2</a></html>
+            </pb-message>
+        {% endif %}
     </pb-rating>
 
     <pb-mrq name="mrq_1_1" question="What do you like in this MRQ?" required_choices='["gracefulness","elegance","beauty"]'>
@@ -41,6 +51,11 @@
         <pb-tip values='["gracefulness"]'>This MRQ is indeed very graceful</pb-tip>
         <pb-tip values='["elegance","beauty"]'>This is something everyone has to like about this MRQ</pb-tip>
         <pb-tip values='["bugs"]'>Nah, there aren't any!</pb-tip>
+        {% if include_review_tips %}
+            <pb-message type="on-assessment-review-question">
+                <html>Take another look at <a href="#">Lesson 3</a></html>
+            </pb-message>
+        {% endif %}
     </pb-mrq>
 
     <pb-message type="on-assessment-review">


### PR DESCRIPTION
This new feature allows content authors to set an optional "review message" on each MCQ/MRQ/Rating question.

The review messages are shown in assessment mode when the student is reviewing their grade before being allowed to try again. The review screen now includes a list of topics to review, based on which questions the student got wrong.

Screenshot:
![screen shot 2015-09-04 at 4 28 44 pm](https://cloud.githubusercontent.com/assets/945577/9696458/ec859738-5324-11e5-97d8-f29becfaaf87.png)

If the student got all the questions right or has no attempts remaining, the new review section is not shown.

Here's how it looks to course authors in Studio:
![screen shot 2015-09-04 at 4 29 13 pm](https://cloud.githubusercontent.com/assets/945577/9696465/00233926-5325-11e5-9f50-1729c5f170fc.png)
