### PR TITLE
New version of mentoring block that supports explicit steps

### DIFF
--- a/problem_builder/__init__.py
+++ b/problem_builder/__init__.py
@@ -1,4 +1,5 @@
-from .mentoring import MentoringBlock
+from .mentoring import MentoringBlock, MentoringWithExplicitStepsBlock
+from .step import MentoringStepBlock
 from .answer import AnswerBlock, AnswerRecapBlock
 from .choice import ChoiceBlock
 from .dashboard import DashboardBlock

--- a/problem_builder/answer.py
+++ b/problem_builder/answer.py
@@ -30,9 +30,9 @@ from xblock.fields import Scope, Float, Integer, String
 from xblock.fragment import Fragment
 from xblock.validation import ValidationMessage
 from xblockutils.resources import ResourceLoader
-from xblockutils.studio_editable import StudioEditableXBlockMixin
+from xblockutils.studio_editable import StudioEditableXBlockMixin, XBlockWithPreviewMixin
 from problem_builder.sub_api import SubmittingXBlockMixin, sub_api
-from .step import StepMixin
+from .mixins import QuestionMixin, XBlockWithTranslationServiceMixin
 import uuid
 
 
@@ -49,7 +49,7 @@ def _(text):
 # Classes ###########################################################
 
 
-class AnswerMixin(object):
+class AnswerMixin(XBlockWithPreviewMixin, XBlockWithTranslationServiceMixin):
     """
     Mixin to give an XBlock the ability to read/write data to the Answers DB table.
     """
@@ -114,19 +114,18 @@ class AnswerMixin(object):
         if not data.name:
             add_error(u"A Question ID is required.")
 
-    def _(self, text):
-        """ translate text """
-        return self.runtime.service(self, "i18n").ugettext(text)
-
 
 @XBlock.needs("i18n")
-class AnswerBlock(SubmittingXBlockMixin, AnswerMixin, StepMixin, StudioEditableXBlockMixin, XBlock):
+class AnswerBlock(SubmittingXBlockMixin, AnswerMixin, QuestionMixin, StudioEditableXBlockMixin, XBlock):
     """
     A field where the student enters an answer
 
     Must be included as a child of a mentoring block. Answers are persisted as django model instances
     to make them searchable and referenceable across xblocks.
     """
+    CATEGORY = 'pb-answer'
+    STUDIO_LABEL = _(u"Long Answer")
+
     name = String(
         display_name=_("Question ID (name)"),
         help=_("The ID of this block. Should be unique unless you want the answer to be used in multiple places."),
@@ -273,6 +272,9 @@ class AnswerRecapBlock(AnswerMixin, StudioEditableXBlockMixin, XBlock):
     """
     A block that displays an answer previously entered by the student (read-only).
     """
+    CATEGORY = 'pb-answer-recap'
+    STUDIO_LABEL = _(u"Long Answer Recap")
+
     name = String(
         display_name=_("Question ID"),
         help=_("The ID of the question for which to display the student's answer."),

--- a/problem_builder/choice.py
+++ b/problem_builder/choice.py
@@ -27,7 +27,9 @@ from xblock.core import XBlock
 from xblock.fields import Scope, String
 from xblock.fragment import Fragment
 from xblock.validation import ValidationMessage
-from xblockutils.studio_editable import StudioEditableXBlockMixin
+from xblockutils.studio_editable import StudioEditableXBlockMixin, XBlockWithPreviewMixin
+
+from problem_builder.mixins import XBlockWithTranslationServiceMixin
 
 
 # Make '_' a no-op so we can scrape strings
@@ -38,7 +40,7 @@ def _(text):
 
 
 @XBlock.needs("i18n")
-class ChoiceBlock(StudioEditableXBlockMixin, XBlock):
+class ChoiceBlock(StudioEditableXBlockMixin, XBlockWithPreviewMixin, XBlockWithTranslationServiceMixin, XBlock):
     """
     Custom choice of an answer for a MCQ/MRQ
     """
@@ -55,10 +57,6 @@ class ChoiceBlock(StudioEditableXBlockMixin, XBlock):
         default="",
     )
     editable_fields = ('content', 'value')
-
-    def _(self, text):
-        """ translate text """
-        return self.runtime.service(self, "i18n").ugettext(text)
 
     @property
     def display_name_with_default(self):

--- a/problem_builder/mcq.py
+++ b/problem_builder/mcq.py
@@ -48,6 +48,9 @@ class MCQBlock(SubmittingXBlockMixin, QuestionnaireAbstractBlock):
     """
     An XBlock used to ask multiple-choice questions
     """
+    CATEGORY = 'pb-mcq'
+    STUDIO_LABEL = _(u"Multiple Choice Question")
+
     student_choice = String(
         # {Last input submitted by the student
         default="",
@@ -158,6 +161,9 @@ class RatingBlock(MCQBlock):
     """
     An XBlock used to rate something on a five-point scale, e.g. Likert Scale
     """
+    CATEGORY = 'pb-rating'
+    STUDIO_LABEL = _(u"Rating Question")
+
     low = String(
         display_name=_("Low"),
         help=_("Label for low ratings"),

--- a/problem_builder/message.py
+++ b/problem_builder/message.py
@@ -26,6 +26,8 @@ from xblock.fields import Scope, String
 from xblock.fragment import Fragment
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 
+from problem_builder.mixins import XBlockWithTranslationServiceMixin
+
 
 # Make '_' a no-op so we can scrape strings
 def _(text):
@@ -35,7 +37,7 @@ def _(text):
 
 
 @XBlock.needs("i18n")
-class MentoringMessageBlock(XBlock, StudioEditableXBlockMixin):
+class MentoringMessageBlock(XBlock, StudioEditableXBlockMixin, XBlockWithTranslationServiceMixin):
     """
     A message which can be conditionally displayed at the mentoring block level,
     for example upon completion of the block
@@ -126,10 +128,6 @@ class MentoringMessageBlock(XBlock, StudioEditableXBlockMixin):
     )
     editable_fields = ("content", )
 
-    def _(self, text):
-        """ translate text """
-        return self.runtime.service(self, "i18n").ugettext(text)
-
     def mentoring_view(self, context=None):
         """ Render this message for use by a mentoring block. """
         html = u'<div class="submission-message {msg_type}">{content}</div>'.format(
@@ -184,3 +182,23 @@ class MentoringMessageBlock(XBlock, StudioEditableXBlockMixin):
             block.content += etree.tostring(child, encoding='unicode')
 
         return block
+
+
+class CompletedMentoringMessageShim(object):
+    CATEGORY = 'pb-message'
+    STUDIO_LABEL = _("Message (Complete)")
+
+
+class IncompleteMentoringMessageShim(object):
+    CATEGORY = 'pb-message'
+    STUDIO_LABEL = _("Message (Incomplete)")
+
+
+class MaxAttemptsReachedMentoringMessageShim(object):
+    CATEGORY = 'pb-message'
+    STUDIO_LABEL = _("Message (Max # Attempts)")
+
+
+class OnAssessmentReviewMentoringMessageShim(object):
+    CATEGORY = 'pb-message'
+    STUDIO_LABEL = _("Message (Assessment Review)")

--- a/problem_builder/mixins.py
+++ b/problem_builder/mixins.py
@@ -1,0 +1,136 @@
+from lazy import lazy
+from xblock.fields import String, Boolean, Scope
+from xblockutils.helpers import child_isinstance
+from xblockutils.resources import ResourceLoader
+
+
+loader = ResourceLoader(__name__)
+
+
+# Make '_' a no-op so we can scrape strings
+def _(text):
+    return text
+
+
+def _normalize_id(key):
+    """
+    Helper method to normalize a key to avoid issues where some keys have version/branch and others don't.
+    e.g. self.scope_ids.usage_id != self.runtime.get_block(self.scope_ids.usage_id).scope_ids.usage_id
+    """
+    if hasattr(key, "for_branch"):
+        key = key.for_branch(None)
+    if hasattr(key, "for_version"):
+        key = key.for_version(None)
+    return key
+
+
+class XBlockWithTranslationServiceMixin(object):
+    """
+    Mixin providing access to i18n service
+    """
+    def _(self, text):
+        """ Translate text """
+        return self.runtime.service(self, "i18n").ugettext(text)
+
+
+class EnumerableChildMixin(XBlockWithTranslationServiceMixin):
+    CAPTION = _(u"Child")
+
+    show_title = Boolean(
+        display_name=_("Show title"),
+        help=_("Display the title?"),
+        default=True,
+        scope=Scope.content
+    )
+
+    @lazy
+    def siblings(self):
+        # TODO: It might make sense to provide a default
+        # implementation here that just returns normalized ID's of the
+        # parent's children.
+        raise NotImplementedError("Should be overridden in child class")
+
+    @lazy
+    def step_number(self):
+        return list(self.siblings).index(_normalize_id(self.scope_ids.usage_id)) + 1
+
+    @lazy
+    def lonely_child(self):
+        if _normalize_id(self.scope_ids.usage_id) not in self.siblings:
+            message = u"{child_caption}'s parent should contain {child_caption}".format(child_caption=self.CAPTION)
+            raise ValueError(message, self, self.siblings)
+        return len(self.siblings) == 1
+
+    @property
+    def display_name_with_default(self):
+        """ Get the title/display_name of this question. """
+        if self.display_name:
+            return self.display_name
+        if not self.lonely_child:
+            return self._(u"{child_caption} {number}").format(
+                child_caption=self.CAPTION, number=self.step_number
+            )
+        return self._(self.CAPTION)
+
+
+class StepParentMixin(object):
+    """
+    An XBlock mixin for a parent block containing Step children
+    """
+
+    @lazy
+    def steps(self):
+        """
+        Get the usage_ids of all of this XBlock's children that are "Steps"
+        """
+        return [
+            _normalize_id(child_id) for child_id in self.children if child_isinstance(self, child_id, QuestionMixin)
+        ]
+
+    def get_steps(self):
+        """ Get the step children of this block, cached if possible. """
+        if getattr(self, "_steps_cache", None) is None:
+            self._steps_cache = [self.runtime.get_block(child_id) for child_id in self.steps]
+        return self._steps_cache
+
+
+class QuestionMixin(EnumerableChildMixin):
+    """
+    An XBlock mixin for a child block that is a "Step".
+
+    A step is a question that the user can answer (as opposed to a read-only child).
+    """
+    CAPTION = _(u"Question")
+
+    has_author_view = True
+
+    # Fields:
+    display_name = String(
+        display_name=_("Question title"),
+        help=_('Leave blank to use the default ("Question 1", "Question 2", etc.)'),
+        default="",  # Blank will use 'Question x' - see display_name_with_default
+        scope=Scope.content
+    )
+
+    @lazy
+    def siblings(self):
+        return self.get_parent().steps
+
+    def author_view(self, context):
+        context = context.copy() if context else {}
+        context['hide_header'] = True
+        return self.mentoring_view(context)
+
+    def author_preview_view(self, context):
+        context = context.copy() if context else {}
+        context['hide_header'] = True
+        return self.student_view(context)
+
+    def assessment_step_view(self, context=None):
+        """
+        assessment_step_view is the same as mentoring_view, except its DIV will have a different
+        class (.xblock-v1-assessment_step_view) that we use for assessments to hide all the
+        steps with CSS and to detect which children of mentoring are "Steps" and which are just
+        decorative elements/instructions.
+        """
+        return self.mentoring_view(context)

--- a/problem_builder/mrq.py
+++ b/problem_builder/mrq.py
@@ -44,6 +44,9 @@ class MRQBlock(QuestionnaireAbstractBlock):
     """
     An XBlock used to ask multiple-response questions
     """
+    CATEGORY = 'pb-mrq'
+    STUDIO_LABEL = _(u"Multiple Response Question")
+
     student_choices = List(
         # Last submissions by the student
         default=[],

--- a/problem_builder/public/css/problem-builder-edit.css
+++ b/problem_builder/public/css/problem-builder-edit.css
@@ -1,9 +1,13 @@
 /* Display of url_name below content */
+.xblock[data-block-type=pb-mentoring-step] .url-name-footer,
+.xblock[data-block-type=pb-mentoring] .url-name-footer,
 .xblock[data-block-type=problem-builder] .url-name-footer,
 .xblock[data-block-type=mentoring] .url-name-footer {
   font-style: italic;
 }
 
+.xblock[data-block-type=pb-mentoring-step] .url-name-footer .url-name,
+.xblock[data-block-type=pb-mentoring] .url-name-footer .url-name,
 .xblock[data-block-type=problem-builder] .url-name-footer .url-name,
 .xblock[data-block-type=mentoring] .url-name-footer .url-name {
   margin: 0 10px;
@@ -11,6 +15,8 @@
 }
 
 /* Custom appearance for our "Add" buttons */
+.xblock[data-block-type=pb-mentoring-step] .add-xblock-component .new-component .new-component-type .add-xblock-component-button,
+.xblock[data-block-type=pb-mentoring] .add-xblock-component .new-component .new-component-type .add-xblock-component-button,
 .xblock[data-block-type=problem-builder] .add-xblock-component .new-component .new-component-type .add-xblock-component-button,
 .xblock[data-block-type=mentoring] .add-xblock-component .new-component .new-component-type .add-xblock-component-button {
   width: 200px;
@@ -18,6 +24,10 @@
   line-height: 30px;
 }
 
+.xblock[data-block-type=pb-mentoring-step] .add-xblock-component .new-component .new-component-type .add-xblock-component-button.disabled,
+.xblock[data-block-type=pb-mentoring-step] .add-xblock-component .new-component .new-component-type .add-xblock-component-button.disabled:hover,
+.xblock[data-block-type=pb-mentoring] .add-xblock-component .new-component .new-component-type .add-xblock-component-button.disabled,
+.xblock[data-block-type=pb-mentoring] .add-xblock-component .new-component .new-component-type .add-xblock-component-button.disabled:hover,
 .xblock[data-block-type=problem-builder] .add-xblock-component .new-component .new-component-type .add-xblock-component-button.disabled,
 .xblock[data-block-type=problem-builder] .add-xblock-component .new-component .new-component-type .add-xblock-component-button.disabled:hover,
 .xblock[data-block-type=mentoring] .add-xblock-component .new-component .new-component-type .add-xblock-component-button.disabled,
@@ -27,6 +37,7 @@
   cursor: default;
 }
 
+.xblock[data-block-type=pb-mentoring] .submission-message-help p,
 .xblock[data-block-type=problem-builder] .submission-message-help p {
 	border-top: 1px solid #ddd;
 	font-size: 0.85em;

--- a/problem_builder/public/js/mentoring_with_steps_edit.js
+++ b/problem_builder/public/js/mentoring_with_steps_edit.js
@@ -1,0 +1,23 @@
+function MentoringWithStepsEdit(runtime, element) {
+    "use strict";
+    // Disable "add" buttons when a message of that type already exists:
+    var $buttons = $('.add-xblock-component-button[data-category=pb-message]', element);
+    var updateButtons = function() {
+        $buttons.each(function() {
+            var msg_type = $(this).data('boilerplate');
+            $(this).toggleClass('disabled', $('.xblock .submission-message.'+msg_type).length > 0);
+        });
+    };
+    updateButtons();
+    $buttons.click(function(ev) {
+        if ($(this).is('.disabled')) {
+            ev.preventDefault();
+            ev.stopPropagation();
+        } else {
+            $(this).addClass('disabled');
+        }
+    });
+
+    ProblemBuilderUtil.transformClarifications(element);
+    StudioEditableXBlockMixin(runtime, element);
+}

--- a/problem_builder/public/js/step_edit.js
+++ b/problem_builder/public/js/step_edit.js
@@ -1,0 +1,5 @@
+function StepEdit(runtime, element) {
+    'use strict';
+    StudioContainerXBlockWithNestedXBlocksMixin(runtime, element);
+    ProblemBuilderUtil.transformClarifications(element);
+}

--- a/problem_builder/questionnaire.py
+++ b/problem_builder/questionnaire.py
@@ -29,12 +29,12 @@ from xblock.fragment import Fragment
 from xblock.validation import ValidationMessage
 from xblockutils.helpers import child_isinstance
 from xblockutils.resources import ResourceLoader
-from xblockutils.studio_editable import StudioEditableXBlockMixin, StudioContainerXBlockMixin
+from xblockutils.studio_editable import StudioEditableXBlockMixin, StudioContainerXBlockMixin, XBlockWithPreviewMixin
 
 from .choice import ChoiceBlock
 from .mentoring import MentoringBlock
 from .message import MentoringMessageBlock
-from .step import StepMixin
+from .mixins import QuestionMixin, XBlockWithTranslationServiceMixin
 from .tip import TipBlock
 
 # Globals ###########################################################
@@ -50,7 +50,10 @@ def _(text):
 
 
 @XBlock.needs("i18n")
-class QuestionnaireAbstractBlock(StudioEditableXBlockMixin, StudioContainerXBlockMixin, StepMixin, XBlock):
+class QuestionnaireAbstractBlock(
+    StudioEditableXBlockMixin, StudioContainerXBlockMixin, QuestionMixin, XBlock, XBlockWithPreviewMixin,
+    XBlockWithTranslationServiceMixin
+):
     """
     An abstract class used for MCQ/MRQ blocks
 
@@ -87,10 +90,6 @@ class QuestionnaireAbstractBlock(StudioEditableXBlockMixin, StudioContainerXBloc
     )
     editable_fields = ('question', 'message', 'weight', 'display_name', 'show_title')
     has_children = True
-
-    def _(self, text):
-        """ translate text """
-        return self.runtime.service(self, "i18n").ugettext(text)
 
     @lazy
     def html_id(self):

--- a/problem_builder/table.py
+++ b/problem_builder/table.py
@@ -30,10 +30,11 @@ from xblock.fields import Scope, String, Boolean, Dict
 from xblock.fragment import Fragment
 
 from xblockutils.resources import ResourceLoader
-from xblockutils.studio_editable import StudioEditableXBlockMixin, StudioContainerXBlockMixin
+from xblockutils.studio_editable import StudioEditableXBlockMixin, StudioContainerXBlockMixin, XBlockWithPreviewMixin
 
 # Globals ###########################################################
-from problem_builder import AnswerRecapBlock
+
+from problem_builder.answer import AnswerRecapBlock
 from problem_builder.dashboard import ExportMixin
 from problem_builder.models import Share
 from problem_builder.sub_api import SubmittingXBlockMixin
@@ -51,7 +52,8 @@ def _(text):
 @XBlock.wants("user")
 @XBlock.wants("submissions")
 class MentoringTableBlock(
-        StudioEditableXBlockMixin, SubmittingXBlockMixin, StudioContainerXBlockMixin, ExportMixin, XBlock
+    StudioEditableXBlockMixin, SubmittingXBlockMixin, StudioContainerXBlockMixin, ExportMixin, XBlock,
+    XBlockWithPreviewMixin
 ):
     """
     Table-type display of information from mentoring blocks
@@ -59,6 +61,9 @@ class MentoringTableBlock(
     Used to present summary of information entered by the students in mentoring blocks.
     Supports different types of formatting through the `type` parameter.
     """
+    CATEGORY = 'pb-table'
+    STUDIO_LABEL = _(u"Answer Recap Table")
+
     display_name = String(
         display_name=_("Display name"),
         help=_("Title of the table"),

--- a/problem_builder/templates/html/step.html
+++ b/problem_builder/templates/html/step.html
@@ -1,0 +1,17 @@
+<div class="pb-step">
+  {% if show_title %}
+  <div class="title">
+    <h3>
+      {% if title %}
+        {{ title }}
+      {% else %}
+        {{ self.display_name_with_default }}
+      {% endif %}
+    </h3>
+  </div>
+  {% endif %}
+
+  {% for child_content in child_contents %}
+    {{ child_content|safe }}
+  {% endfor %}
+</div>

--- a/problem_builder/tests/unit/test_step.py
+++ b/problem_builder/tests/unit/test_step.py
@@ -1,6 +1,6 @@
 import unittest
 
-from problem_builder.step import StepMixin, StepParentMixin
+from problem_builder.mixins import QuestionMixin, StepParentMixin
 from mock import Mock
 
 
@@ -32,7 +32,7 @@ class BaseClass(object):
     pass
 
 
-class Step(BaseClass, StepMixin):
+class Step(BaseClass, QuestionMixin):
     def __init__(self):
         pass
 
@@ -41,7 +41,7 @@ class NotAStep(object):
     pass
 
 
-class TestStepMixin(unittest.TestCase):
+class TestQuestionMixin(unittest.TestCase):
     def test_single_step_is_returned_correctly(self):
         block = Parent()
         step = Step()
@@ -77,18 +77,18 @@ class TestStepMixin(unittest.TestCase):
         self.assertEquals(step1.step_number, 2)
         self.assertEquals(step2.step_number, 1)
 
-    def test_lonely_step_is_true_for_stand_alone_steps(self):
+    def test_lonely_child_is_true_for_stand_alone_steps(self):
         block = Parent()
         step1 = Step()
         block._set_children_for_test(1, "2", step1, "Step", NotAStep(), False)
 
-        self.assertTrue(step1.lonely_step)
+        self.assertTrue(step1.lonely_child)
 
-    def test_lonely_step_is_true_if_parent_have_more_steps(self):
+    def test_lonely_child_is_true_if_parent_have_more_steps(self):
         block = Parent()
         step1 = Step()
         step2 = Step()
         block._set_children_for_test(1, step2, "2", step1, "Step", NotAStep(), False)
 
-        self.assertFalse(step1.lonely_step)
-        self.assertFalse(step2.lonely_step)
+        self.assertFalse(step1.lonely_child)
+        self.assertFalse(step2.lonely_child)

--- a/problem_builder/tip.py
+++ b/problem_builder/tip.py
@@ -30,6 +30,8 @@ from xblock.validation import ValidationMessage
 from xblockutils.resources import ResourceLoader
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 
+from problem_builder.mixins import XBlockWithTranslationServiceMixin
+
 loader = ResourceLoader(__name__)
 
 
@@ -41,7 +43,7 @@ def _(text):
 
 
 @XBlock.needs("i18n")
-class TipBlock(StudioEditableXBlockMixin, XBlock):
+class TipBlock(StudioEditableXBlockMixin, XBlockWithTranslationServiceMixin, XBlock):
     """
     Each choice can define a tip depending on selection
     """
@@ -72,10 +74,6 @@ class TipBlock(StudioEditableXBlockMixin, XBlock):
         default=''
     )
     editable_fields = ('values', 'content', 'width', 'height')
-
-    def _(self, text):
-        """ translate text """
-        return self.runtime.service(self, "i18n").ugettext(text)
 
     @property
     def display_name_with_default(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ddt
 mock
 unicodecsv==0.9.4
--e git+https://github.com/edx/xblock-utils.git@213a97a50276d6a2504d8133650b2930ead357a0#egg=xblock-utils
+-e git+https://github.com/edx/xblock-utils.git@3b58c757f06943072b170654d676e95b9adb37b0#egg=xblock-utils
 -e .

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ def package_data(pkg, root_list):
 
 BLOCKS = [
     'problem-builder = problem_builder:MentoringBlock',
+    'pb-mentoring = problem_builder:MentoringWithExplicitStepsBlock',
+    'pb-mentoring-step = problem_builder:MentoringStepBlock',
 
     'pb-table = problem_builder:MentoringTableBlock',
     'pb-column = problem_builder:MentoringTableColumn',


### PR DESCRIPTION
This PR introduces two new blocks and enables support for viewing and editing them in Studio. One of the blocks is a new version of `MentoringBlock` that supports explicit steps, the other one is a block that represents a step:

-  The new mentoring block only allows step blocks (any number) and mentoring-wide messages as direct children.
-   The step block hosts all blocks that can not be added to new mentoring block (MCQ, MRQ, Long Answer, etc.)

**Acceptance criteria**

Studio integration:

-   [X] Make it possible to add new mentoring block to unit
-   [X] Make it possible to **add** step blocks
-   [X] Make it possible to **edit** step blocks
-   [X] Make it possible to **remove** step blocks
-   [X] Make it possible to **add step contents**
-   [X] Previews at mentoring and step levels should function properly
    -   [X] inner blocks should not have a studio header (small glitch: at mentoring level, HTML block still has a header)
    -   [X] inner blocks should look more or less the same as they would in LMS
    -   [X] inner blocks should have no obvious styling glitches and pass other common-sense checks

**Testing**

1. Enable new mentoring block for a course in Studio by adding `pb-mentoring` to advanced modules.
2. Add new mentoring block to a (new or existing) unit by choosing "Mentoring Questions (with explicit steps)" from the list of "Advanced" blocks.
3. Click "View" to edit the components of the block. Observe that the options for blocks to add are restricted to step and message blocks.
4. Add a step block.
5. Click "View" to edit the components of the block. Observe that the options for blocks to add include all relevant blocks that can not be added to the top level of the new mentoring block.
6. Try adding and removing a few components to/from the step block.
7. On the previous (mentoring) level, click "Edit" to change e.g. the title of the step block.
8. Click the trash icon to remove the step block.