### PR TITLE
Step navigation and submission for new mentoring block

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Alan Boudreault <boudreault.alan@gmail.com>
 Eugeny Kolpakov <eugeny@opencraft.com>
 Braden MacDonald <braden@opencraft.com>
 Jonathan Piacenti <jonathan@opencraft.com>
+Tim Krones <tim@opencraft.com>

--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -916,6 +916,19 @@ class MentoringWithExplicitStepsBlock(BaseMentoringBlock, StudioContainerWithNes
             'step': self.step
         }
 
+    @XBlock.json_handler
+    def try_again(self, data, suffix=''):
+        self.step = 0
+
+        step_blocks = [self.runtime.get_block(child_id) for child_id in self.steps]
+
+        for step in step_blocks:
+            step.reset()
+
+        return {
+            'result': 'success'
+        }
+
     def author_edit_view(self, context):
         """
         Add some HTML to the author view that allows authors to add child blocks.

--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -865,15 +865,18 @@ class MentoringWithExplicitStepsBlock(BaseMentoringBlock, StudioContainerWithNes
                 fragment.add_frag_resources(child_fragment)
                 child_content += child_fragment.content
 
-        fragment.add_content(loader.render_template('templates/html/mentoring.html', {
+        fragment.add_content(loader.render_template('templates/html/mentoring_with_steps.html', {
             'self': self,
             'title': self.display_name,
             'show_title': self.show_title,
             'child_content': child_content,
         }))
         fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/problem-builder.css'))
+        fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/mentoring_with_steps.js'))
 
         self.include_theme_files(fragment)
+
+        fragment.initialize_js('MentoringWithStepsBlock')
 
         return fragment
 

--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -834,6 +834,14 @@ class MentoringWithExplicitStepsBlock(BaseMentoringBlock, StudioContainerWithNes
         scope=Scope.settings
     )
 
+    # User state
+    step = Integer(
+        # Keep track of the student progress.
+        default=0,
+        scope=Scope.user_state,
+        enforce_type=True
+    )
+
     editable_fields = ('display_name',)
 
     @lazy
@@ -899,6 +907,14 @@ class MentoringWithExplicitStepsBlock(BaseMentoringBlock, StudioContainerWithNes
             NestedXBlockSpec(MaxAttemptsReachedMentoringMessageShim, boilerplate='max_attempts_reached'),
             NestedXBlockSpec(OnAssessmentReviewMentoringMessageShim, boilerplate='on-assessment-review'),
         ]
+
+    @XBlock.json_handler
+    def update_step(self, step, suffix=''):
+        if step < len(self.steps):
+            self.step = step
+        return {
+            'step': self.step
+        }
 
     def author_edit_view(self, context):
         """

--- a/problem_builder/public/js/mentoring_with_steps.js
+++ b/problem_builder/public/js/mentoring_with_steps.js
@@ -1,0 +1,46 @@
+function MentoringWithStepsBlock(runtime, element) {
+
+    var steps = runtime.children(element).filter(
+        function(c) { return c.element.className.indexOf('pb-mentoring-step') > -1; }
+    );
+    var active_child = -1;
+    var nextDOM;
+
+    function isLastChild() {
+        return (active_child === steps.length-1);
+    }
+
+    function hideAllSteps() {
+        for (var i=0; i < steps.length; i++) {
+            $(steps[i].element).hide();
+        }
+    }
+
+    function displayNextChild() {
+        hideAllSteps();
+        findNextChild();
+        if (isLastChild()) {
+            nextDOM.attr('disabled', 'disabled');
+        }
+    }
+
+    function findNextChild() {
+        // find the next real child block to display. HTMLBlock are always displayed
+        ++active_child;
+        var child = steps[active_child];
+        $(child.element).show();
+    }
+
+    function initXBlockView() {
+
+        displayNextChild();
+
+        nextDOM = $(element).find('.submit .input-next');
+        nextDOM.bind('click', displayNextChild);
+        nextDOM.removeAttr('disabled');
+        nextDOM.show();
+    }
+
+    initXBlockView();
+
+}

--- a/problem_builder/public/js/mentoring_with_steps.js
+++ b/problem_builder/public/js/mentoring_with_steps.js
@@ -3,14 +3,27 @@ function MentoringWithStepsBlock(runtime, element) {
     var steps = runtime.children(element).filter(
         function(c) { return c.element.className.indexOf('pb-mentoring-step') > -1; }
     );
-    var active_child = -1;
-    var checkmark, submitDOM, nextDOM;
+    var step = $('.mentoring', element).data('step');
+    var active_child, checkmark, submitDOM, nextDOM;
 
     function isLastChild() {
         return (active_child === steps.length-1);
     }
 
+    function updateStep() {
+        var handlerUrl = runtime.handlerUrl(element, 'update_step');
+        $.post(handlerUrl, JSON.stringify(step+1))
+            .success(function(response) {
+                step = response.step;
+                console.log('Step: ' + step);
+            });
+    }
+
     function handleResults(response) {
+        // Update step so next step is shown on page reload (even if user does not click "Next Step")
+        updateStep();
+
+        // Update UI
         if (response.completed === 'correct') {
             checkmark.addClass('checkmark-correct icon-ok fa-check');
         } else if (response.completed === 'partial') {
@@ -106,6 +119,8 @@ function MentoringWithStepsBlock(runtime, element) {
         };
         initSteps(options);
 
+        active_child = step;
+        active_child -= 1;
         displayNextChild();
     }
 

--- a/problem_builder/public/js/mentoring_with_steps.js
+++ b/problem_builder/public/js/mentoring_with_steps.js
@@ -4,7 +4,7 @@ function MentoringWithStepsBlock(runtime, element) {
         function(c) { return c.element.className.indexOf('pb-mentoring-step') > -1; }
     );
     var active_child = -1;
-    var nextDOM;
+    var submitDOM, nextDOM;
 
     function isLastChild() {
         return (active_child === steps.length-1);
@@ -22,6 +22,7 @@ function MentoringWithStepsBlock(runtime, element) {
         if (isLastChild()) {
             nextDOM.attr('disabled', 'disabled');
         }
+        validateXBlock();
     }
 
     function findNextChild() {
@@ -31,14 +32,45 @@ function MentoringWithStepsBlock(runtime, element) {
         $(child.element).show();
     }
 
-    function initXBlockView() {
+    function onChange() {
+        validateXBlock();
+    }
 
-        displayNextChild();
+    function validateXBlock() {
+        var is_valid = true;
+        var child = steps[active_child];
+        if (child) {
+            is_valid = child['validate']();
+        }
+        if (!is_valid) {
+            submitDOM.attr('disabled', 'disabled');
+        } else {
+            submitDOM.removeAttr('disabled');
+        }
+    }
+
+    function initSteps(options) {
+        for (var i=0; i < steps.length; i++) {
+            var step = steps[i];
+            step['initChildren'](options);
+        }
+    }
+
+    function initXBlockView() {
+        submitDOM = $(element).find('.submit .input-main');
+        submitDOM.show();
 
         nextDOM = $(element).find('.submit .input-next');
         nextDOM.bind('click', displayNextChild);
         nextDOM.removeAttr('disabled');
         nextDOM.show();
+
+        var options = {
+            onChange: onChange
+        };
+        initSteps(options);
+
+        displayNextChild();
     }
 
     initXBlockView();

--- a/problem_builder/public/js/step.js
+++ b/problem_builder/public/js/step.js
@@ -1,0 +1,38 @@
+function MentoringStepBlock(runtime, element) {
+
+    var children = runtime.children(element);
+
+    function callIfExists(obj, fn) {
+        if (typeof obj !== 'undefined' && typeof obj[fn] == 'function') {
+            return obj[fn].apply(obj, Array.prototype.slice.call(arguments, 2));
+        } else {
+            return null;
+        }
+    }
+
+    return {
+
+        initChildren: function(options) {
+            for (var i=0; i < children.length; i++) {
+                var child = children[i];
+                callIfExists(child, 'init', options);
+            }
+        },
+
+        validate: function() {
+            var is_valid = true;
+            for (var i = 0; i < children.length; i++) {
+                var child = children[i];
+                if (child && child.name !== undefined) {
+                    var child_validation = callIfExists(child, 'validate');
+                    if (_.isBoolean(child_validation)) {
+                        is_valid = is_valid && child_validation;
+                    }
+                }
+            }
+            return is_valid;
+        }
+
+    };
+
+}

--- a/problem_builder/public/js/step.js
+++ b/problem_builder/public/js/step.js
@@ -1,6 +1,7 @@
 function MentoringStepBlock(runtime, element) {
 
     var children = runtime.children(element);
+    var submitXHR;
 
     function callIfExists(obj, fn) {
         if (typeof obj !== 'undefined' && typeof obj[fn] == 'function') {
@@ -31,6 +32,25 @@ function MentoringStepBlock(runtime, element) {
                 }
             }
             return is_valid;
+        },
+
+        submit: function(result_handler) {
+            var handler_name = 'submit';
+            var data = {};
+            for (var i = 0; i < children.length; i++) {
+                var child = children[i];
+                if (child && child.name !== undefined && typeof(child[handler_name]) !== "undefined") {
+                    data[child.name.toString()] = child[handler_name]();
+                }
+            }
+            var handlerUrl = runtime.handlerUrl(element, handler_name);
+            if (submitXHR) {
+                submitXHR.abort();
+            }
+            submitXHR = $.post(handlerUrl, JSON.stringify(data))
+                .success(function(response) {
+                    result_handler(response);
+                });
         }
 
     };

--- a/problem_builder/step.py
+++ b/problem_builder/step.py
@@ -18,12 +18,13 @@
 # "AGPLv3".  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import logging
+
 from lazy.lazy import lazy
 
 from xblock.core import XBlock
-from xblock.fields import String, Boolean, Scope
+from xblock.fields import String, List, Scope
 from xblock.fragment import Fragment
-from xblockutils.helpers import child_isinstance
 from xblockutils.resources import ResourceLoader
 from xblockutils.studio_editable import (
     NestedXBlockSpec, StudioEditableXBlockMixin, StudioContainerWithNestedXBlocksMixin, XBlockWithPreviewMixin
@@ -31,11 +32,12 @@ from xblockutils.studio_editable import (
 
 from problem_builder.answer import AnswerBlock, AnswerRecapBlock
 from problem_builder.mcq import MCQBlock, RatingBlock
-from problem_builder.mixins import EnumerableChildMixin
+from problem_builder.mixins import EnumerableChildMixin, StepParentMixin
 from problem_builder.mrq import MRQBlock
 from problem_builder.table import MentoringTableBlock
 
 
+log = logging.getLogger(__name__)
 loader = ResourceLoader(__name__)
 
 
@@ -64,7 +66,7 @@ class HtmlBlockShim(object):
 @XBlock.needs('i18n')
 class MentoringStepBlock(
         StudioEditableXBlockMixin, StudioContainerWithNestedXBlocksMixin, XBlockWithPreviewMixin,
-        EnumerableChildMixin, XBlock
+        EnumerableChildMixin, StepParentMixin, XBlock
 ):
     """
     An XBlock for a step.
@@ -79,6 +81,11 @@ class MentoringStepBlock(
         help=_('Leave blank to use sequential numbering'),
         default="",
         scope=Scope.content
+    )
+    student_results = List(
+        # Store results of student choices.
+        default=[],
+        scope=Scope.user_state
     )
 
     editable_fields = ('display_name', 'show_title',)
@@ -104,13 +111,38 @@ class MentoringStepBlock(
             AnswerRecapBlock, MentoringTableBlock,
         ]
 
-    @property
-    def steps(self):
-        """ Get the usage_ids of all of this XBlock's children that are "Questions" """
-        from mixins import QuestionMixin
-        return [
-            _normalize_id(child_id) for child_id in self.children if child_isinstance(self, child_id, QuestionMixin)
-        ]
+    @XBlock.json_handler
+    def submit(self, submissions, suffix=''):
+        log.info(u'Received submissions: {}'.format(submissions))
+
+        # Submit child blocks (questions) and gather results
+        submit_results = []
+        for child in self.get_steps():
+            if child.name and child.name in submissions:
+                submission = submissions[child.name]
+                child_result = child.submit(submission)
+                submit_results.append([child.name, child_result])
+                child.save() # FIXME: Is this necessary? Child blocks also save themselves ...
+
+        # Update results stored for this step
+        while self.student_results:
+            self.student_results.pop()
+        for result in submit_results:
+            self.student_results.append(result)
+
+        # Compute "answer status" for this step
+        if all(result[1]['status'] == 'correct' for result in submit_results):
+            completed = 'correct'
+        elif all(result[1]['status'] == 'incorrect' for result in submit_results):
+            completed = 'incorrect'
+        else:
+            completed = 'partial'
+
+        return {
+            'message': 'Success!',
+            'completed': completed,
+            'results': submit_results,
+        }
 
     def author_edit_view(self, context):
         """

--- a/problem_builder/step.py
+++ b/problem_builder/step.py
@@ -146,6 +146,10 @@ class MentoringStepBlock(
             'results': submit_results,
         }
 
+    def reset(self):
+        while self.student_results:
+            self.student_results.pop()
+
     def author_edit_view(self, context):
         """
         Add some HTML to the author view that allows authors to add child blocks.

--- a/problem_builder/step.py
+++ b/problem_builder/step.py
@@ -58,6 +58,12 @@ def _normalize_id(key):
     return key
 
 
+class Correctness(object):
+    CORRECT = 'correct'
+    PARTIAL = 'partial'
+    INCORRECT = 'incorrect'
+
+
 class HtmlBlockShim(object):
     CATEGORY = 'html'
     STUDIO_LABEL = _(u"HTML")
@@ -127,18 +133,17 @@ class MentoringStepBlock(
                 child.save()
 
         # Update results stored for this step
-        while self.student_results:
-            self.student_results.pop()
+        self.reset()
         for result in submit_results:
             self.student_results.append(result)
 
         # Compute "answer status" for this step
         if all(result[1]['status'] == 'correct' for result in submit_results):
-            completed = 'correct'
+            completed = Correctness.CORRECT
         elif all(result[1]['status'] == 'incorrect' for result in submit_results):
-            completed = 'incorrect'
+            completed = Correctness.INCORRECT
         else:
-            completed = 'partial'
+            completed = Correctness.PARTIAL
 
         return {
             'message': 'Success!',

--- a/problem_builder/step.py
+++ b/problem_builder/step.py
@@ -160,4 +160,7 @@ class MentoringStepBlock(
             'child_contents': child_contents,
         }))
 
+        fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/step.js'))
+        fragment.initialize_js('MentoringStepBlock')
+
         return fragment

--- a/problem_builder/step.py
+++ b/problem_builder/step.py
@@ -124,7 +124,7 @@ class MentoringStepBlock(
                 submission = submissions[child.name]
                 child_result = child.submit(submission)
                 submit_results.append([child.name, child_result])
-                child.save() # FIXME: Is this necessary? Child blocks also save themselves ...
+                child.save()
 
         # Update results stored for this step
         while self.student_results:

--- a/problem_builder/step.py
+++ b/problem_builder/step.py
@@ -75,13 +75,15 @@ class MentoringStepBlock(
     STUDIO_LABEL = _(u"Mentoring Step")
     CATEGORY = 'pb-mentoring-step'
 
-    # Fields:
+    # Settings
     display_name = String(
         display_name=_("Step Title"),
         help=_('Leave blank to use sequential numbering'),
         default="",
         scope=Scope.content
     )
+
+    # User state
     student_results = List(
         # Store results of student choices.
         default=[],

--- a/problem_builder/templates/html/mentoring_with_steps.html
+++ b/problem_builder/templates/html/mentoring_with_steps.html
@@ -13,6 +13,7 @@
       <span class="assessment-checkmark fa icon-2x"></span>
       <input type="button" class="input-main" value="Submit" disabled="disabled" />
       <input type="button" class="input-next" value="Next Step" disabled="disabled" />
+      <input type="button" class="input-try-again" value="Try again" disabled="disabled" />
     </div>
   </div>
 

--- a/problem_builder/templates/html/mentoring_with_steps.html
+++ b/problem_builder/templates/html/mentoring_with_steps.html
@@ -10,6 +10,7 @@
   <div class="assessment-question-block">
     {{child_content|safe}}
     <div class="submit">
+      <input type="button" class="input-main" value="Submit" disabled="disabled" />
       <input type="button" class="input-next" value="Next Step" disabled="disabled" />
     </div>
   </div>

--- a/problem_builder/templates/html/mentoring_with_steps.html
+++ b/problem_builder/templates/html/mentoring_with_steps.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div class="mentoring themed-xblock" data-step="{{ self.step }}">
+<div class="mentoring themed-xblock" data-active-step="{{ self.active_step }}">
 
   {% if show_title and title %}
   <div class="title">
@@ -8,7 +8,11 @@
   {% endif %}
 
   <div class="assessment-question-block">
-    {{child_content|safe}}
+
+    {% for child_content in children_contents %}
+      {{ child_content|safe }}
+    {% endfor %}
+
     <div class="submit">
       <span class="assessment-checkmark fa icon-2x"></span>
       <input type="button" class="input-main" value="Submit" disabled="disabled" />

--- a/problem_builder/templates/html/mentoring_with_steps.html
+++ b/problem_builder/templates/html/mentoring_with_steps.html
@@ -1,0 +1,17 @@
+{% load i18n %}
+<div class="mentoring themed-xblock" data-step="{{ self.step }}">
+
+  {% if show_title and title %}
+  <div class="title">
+    <h2>{{ title }}</h2>
+  </div>
+  {% endif %}
+
+  <div class="assessment-question-block">
+    {{child_content|safe}}
+    <div class="submit">
+      <input type="button" class="input-next" value="Next Step" disabled="disabled" />
+    </div>
+  </div>
+
+</div>

--- a/problem_builder/templates/html/mentoring_with_steps.html
+++ b/problem_builder/templates/html/mentoring_with_steps.html
@@ -10,6 +10,7 @@
   <div class="assessment-question-block">
     {{child_content|safe}}
     <div class="submit">
+      <span class="assessment-checkmark fa icon-2x"></span>
       <input type="button" class="input-main" value="Submit" disabled="disabled" />
       <input type="button" class="input-next" value="Next Step" disabled="disabled" />
     </div>


### PR DESCRIPTION
This PR adds step navigation and submission functionality to the new blocks introduced in #62.

* New mentoring block now displays one step at a time.
* New step block allows to submit step results. Info about last step submitted is saved at mentoring level so users are taken to the correct step when resuming their work (or reloading the page).
* New mentoring block allows to navigate to next step after submitting step results.
* After submitting the last step, new mentoring block displays a "Try again" button that allows to reset the block and start from scratch. (This functionality will be moved to the review step as part of OC-913.)

**Screenshots**

New mentoring block displaying a single step (with multiple questions):

![new-mentoring-block-displaying-single-step](https://cloud.githubusercontent.com/assets/961441/9953465/5fe8867e-5de1-11e5-9620-0d8c408d42a2.png)

After submitting the current step (all answers correct):

![controls-after-submit-all-correct](https://cloud.githubusercontent.com/assets/961441/9953470/6be13f66-5de1-11e5-89fa-feba75434947.png)

After submitting the current step (some answers correct):

![controls-after-submit-some-correct](https://cloud.githubusercontent.com/assets/961441/9953473/72382c30-5de1-11e5-9730-588f48e12540.png)

After submitting the current step (no correct answers):

![controls-after-submit-none-correct](https://cloud.githubusercontent.com/assets/961441/9953477/79ebdb20-5de1-11e5-8265-f1c7a1cdd50b.png)
