### PR TITLE
Make sure messages get jump_to_id URLs rewritten.

### DIFF
--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -469,6 +469,8 @@ class MentoringBlock(BaseMentoringBlock, StudioContainerXBlockMixin, StepParentM
             if result and result.get('status') != 'correct':
                 # The student got this wrong. Check if there is a review tip to show.
                 tip_html = child.get_review_tip()
+                if hasattr(self.runtime, 'replace_jump_to_id_urls'):
+                    tip_html = self.runtime.replace_jump_to_id_urls(tip_html)
                 if tip_html:
                     review_tips.append(tip_html)
         return review_tips
@@ -746,7 +748,10 @@ class MentoringBlock(BaseMentoringBlock, StudioContainerXBlockMixin, StepParentM
             if child_isinstance(self, child_id, MentoringMessageBlock):
                 child = self.runtime.get_block(child_id)
                 if child.type == message_type:
-                    return child.content
+                    content = child.content
+                    if hasattr(self.runtime, 'replace_jump_to_id_urls'):
+                        content = self.runtime.replace_jump_to_id_urls(content)
+                    return content
         if or_default:
             # Return the default value since no custom message is set.
             # Note the WYSIWYG editor usually wraps the .content HTML in a <p> tag so we do the same here.


### PR DESCRIPTION
@bradenmacdonald @e-kolpakov @antoviaque 

To test this:
1. Create an MCQ with a message sub-block that has a /jump_to_id/<id_hash> url link in it.
2. Add in a message feedback block that also has one.
3. Set the mode to assessment.
4. Fail to answer the MCQ correctly, see the results page, check the links to see if they work.