### PR TITLE
Problem Builder: Fix submission of incorrect questions without review tips

### DIFF
--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -510,9 +510,9 @@ class MentoringBlock(BaseMentoringBlock, StudioContainerXBlockMixin, StepParentM
             if result and result.get('status') != 'correct':
                 # The student got this wrong. Check if there is a review tip to show.
                 tip_html = child.get_review_tip()
-                if hasattr(self.runtime, 'replace_jump_to_id_urls'):
-                    tip_html = self.runtime.replace_jump_to_id_urls(tip_html)
                 if tip_html:
+                    if hasattr(self.runtime, 'replace_jump_to_id_urls'):
+                        tip_html = self.runtime.replace_jump_to_id_urls(tip_html)
                     review_tips.append(tip_html)
         return review_tips
 

--- a/problem_builder/tests/unit/test_mentoring.py
+++ b/problem_builder/tests/unit/test_mentoring.py
@@ -168,3 +168,19 @@ class TestMentoringBlockJumpToIds(unittest.TestCase):
         self.block.steps = [self.mcq_block]
         self.block.student_results = {'test_mcq': {'status': 'incorrect'}}
         self.assertEqual(self.block.review_tips, ['replaced-url'])
+
+    def test_get_tip_content_no_tips(self):
+        self.mcq_block = MCQBlock(self.runtime_mock, DictFieldData({'name': 'test_mcq'}), Mock())
+        self.mcq_block.get_review_tip = Mock()
+        # If there are no review tips, get_review_tip will return None;
+        # simulate this situation here:
+        self.mcq_block.get_review_tip.return_value = None
+        self.block.step_ids = []
+        self.block.steps = [self.mcq_block]
+        self.block.student_results = {'test_mcq': {'status': 'incorrect'}}
+        try:
+            review_tips = self.block.review_tips
+        except TypeError:
+            self.fail('Trying to replace jump_to_id URLs in non-existent review tips.')
+        else:
+            self.assertEqual(review_tips, [])


### PR DESCRIPTION
This PR fixes the following regression:

If the last question belonging to a mentoring block is an MCQ/MRQ and has no "Assessment Review" message component, it can't be submitted. The error happens only when trying to submit a wrong answer.

**Testing**

1. Add Problem Builder block to unit.
2. Temporarily enable mode switching by adding `mode` to `editable_fields` (mentoring.py, line 321):
    
    ```python
    editable_fields = (
        'display_name', 'followed_by', 'max_attempts', 'enforce_dependency',
        'display_submit', 'feedback_label', 'weight', 'extended_feedback', 'mode'
    )
    ```
   This is necessary because mode switching was disabled in #66 (as a first step towards deprecating assessment functionality of Problem Builder), and the bug only affects assessment mode.
3. Set mode to "assessment".
4. Add an MCQ, a Rating, and an MRQ to the block.
    - Make sure **not** to add review tips ("Message (Assessment Review)" blocks) to these questions.
    - Make sure to uncheck some "Accepted Choice[s]" for the rating questions so that you can submit an incorrect answer later.
5. Complete block in the LMS, submitting an incorrect answer for each question. Observe that it is possible to submit answers and get to the next step without having to reload the page.
6.  Verify that there are no `TypeError`s in the server logs.
