### PR TITLE
Step Builder: Allow re-adding children after removing them and (un)lock unit navigation when appropriate

### DIFF
--- a/problem_builder/public/js/mentoring_with_steps.js
+++ b/problem_builder/public/js/mentoring_with_steps.js
@@ -178,6 +178,11 @@ function MentoringWithStepsBlock(runtime, element) {
     function updateDisplay() {
         cleanAll();
         if (atReviewStep()) {
+            // Tell supporting runtimes to enable navigation between units;
+            // user is currently not in the middle of an attempt
+            // so it makes sense for them to be able to leave the current unit by clicking arrow buttons
+            notify('navigation', {state: 'unlock'});
+
             showReviewStep();
             showAttempts();
         } else {
@@ -324,6 +329,11 @@ function MentoringWithStepsBlock(runtime, element) {
     }
 
     function showGrade() {
+        // Tell supporting runtimes to enable navigation between units;
+        // user is currently not in the middle of an attempt
+        // so it makes sense for them to be able to leave the current unit by clicking arrow buttons
+        notify('navigation', {state: 'unlock'});
+
         cleanAll();
         showReviewStep();
         showAttempts();
@@ -343,6 +353,11 @@ function MentoringWithStepsBlock(runtime, element) {
     }
 
     function handleTryAgain(result) {
+        // Tell supporting runtimes to disable navigation between units;
+        // this keeps users from accidentally clicking arrow buttons
+        // and interrupting their experience with the current unit
+        notify('navigation', {state: 'lock'});
+
         activeStep = result.active_step;
         clearSelections();
         updateDisplay();
@@ -364,6 +379,13 @@ function MentoringWithStepsBlock(runtime, element) {
         submitXHR = $.post(handlerUrl, JSON.stringify({})).success(handleTryAgain);
     }
 
+    function notify(name, data){
+        // Notification interface does not exist in the workbench.
+        if (runtime.notify) {
+            runtime.notify(name, data);
+        }
+    }
+
     function initClickHandlers() {
         $(document).on("click", function(event, ui) {
             var target = $(event.target);
@@ -382,6 +404,11 @@ function MentoringWithStepsBlock(runtime, element) {
     }
 
     function initXBlockView() {
+        // Tell supporting runtimes to disable navigation between units;
+        // this keeps users from accidentally clicking arrow buttons
+        // and interrupting their experience with the current unit
+        notify('navigation', {state: 'lock'});
+
         // Hide steps until we're ready
         hideAllSteps();
 

--- a/problem_builder/public/js/mentoring_with_steps_edit.js
+++ b/problem_builder/public/js/mentoring_with_steps_edit.js
@@ -1,6 +1,8 @@
 function MentoringWithStepsEdit(runtime, element) {
     "use strict";
 
+    var $buttons = $('.add-xblock-component-button[data-category=sb-review-step]', element);
+
     var blockIsPresent = function(klass) {
         return $('.xblock ' + klass).length > 0;
     };
@@ -18,21 +20,26 @@ function MentoringWithStepsEdit(runtime, element) {
         }
     };
 
-    var initButtons = function(dataCategory) {
-        var $buttons = $('.add-xblock-component-button[data-category='+dataCategory+']', element);
-        $buttons.each(function() {
-            updateButton($(this), blockIsPresent('.xblock-header-sb-review-step'));
+    var updateButtons = function(buttons) {
+        buttons.each(function() {
+            var button = $(this);
+            updateButton(button, blockIsPresent('.xblock-header-sb-review-step'));
         });
+    };
+
+    var initButtons = function() {
+        updateButtons($buttons);
         $buttons.on('click', disableButton);
     };
 
-    var updateButtons = function() {
-        initButtons('sb-review-step');
+    var resetButtons = function() {
+        var $disabledButtons = $buttons.filter('.disabled');
+        updateButtons($disabledButtons);
     };
 
     ProblemBuilderUtil.transformClarifications(element);
 
-    updateButtons();
-    runtime.listenTo('deleted-child', updateButtons);
+    initButtons();
+    runtime.listenTo('deleted-child', resetButtons);
 
 }

--- a/problem_builder/public/js/mentoring_with_steps_edit.js
+++ b/problem_builder/public/js/mentoring_with_steps_edit.js
@@ -26,8 +26,13 @@ function MentoringWithStepsEdit(runtime, element) {
         $buttons.on('click', disableButton);
     };
 
-    initButtons('sb-review-step');
+    var updateButtons = function() {
+        initButtons('sb-review-step');
+    };
 
     ProblemBuilderUtil.transformClarifications(element);
-    StudioEditableXBlockMixin(runtime, element);
+
+    updateButtons();
+    runtime.listenTo('deleted-child', updateButtons);
+
 }

--- a/problem_builder/public/js/review_step_edit.js
+++ b/problem_builder/public/js/review_step_edit.js
@@ -27,8 +27,13 @@ function ReviewStepEdit(runtime, element) {
         $buttons.on('click', disableButton);
     };
 
-    initButtons('pb-message');
+    var updateButtons = function() {
+        initButtons('pb-message');
+    };
 
     ProblemBuilderUtil.transformClarifications(element);
-    StudioEditableXBlockMixin(runtime, element);
+
+    updateButtons();
+    runtime.listenTo('deleted-child', updateButtons);
+
 }

--- a/problem_builder/public/js/review_step_edit.js
+++ b/problem_builder/public/js/review_step_edit.js
@@ -1,6 +1,8 @@
 function ReviewStepEdit(runtime, element) {
     "use strict";
 
+    var $buttons = $('.add-xblock-component-button[data-category=pb-message]', element);
+
     var blockIsPresent = function(klass) {
         return $('.xblock ' + klass).length > 0;
     };
@@ -18,22 +20,27 @@ function ReviewStepEdit(runtime, element) {
         }
     };
 
-    var initButtons = function(dataCategory) {
-        var $buttons = $('.add-xblock-component-button[data-category='+dataCategory+']', element);
-        $buttons.each(function() {
-            var msg_type = $(this).data('boilerplate');
-            updateButton($(this), blockIsPresent('.submission-message.'+msg_type));
+    var updateButtons = function(buttons) {
+        buttons.each(function() {
+            var button = $(this);
+            var msgType = button.data('boilerplate');
+            updateButton(button, blockIsPresent('.submission-message.'+msgType));
         });
+    };
+
+    var initButtons = function() {
+        updateButtons($buttons);
         $buttons.on('click', disableButton);
     };
 
-    var updateButtons = function() {
-        initButtons('pb-message');
+    var resetButtons = function() {
+        var $disabledButtons = $buttons.filter('.disabled');
+        updateButtons($disabledButtons);
     };
 
     ProblemBuilderUtil.transformClarifications(element);
 
-    updateButtons();
-    runtime.listenTo('deleted-child', updateButtons);
+    initButtons();
+    runtime.listenTo('deleted-child', resetButtons);
 
 }


### PR DESCRIPTION
This PR fixes the following issues:

1. When removing a Review Step child from a Step Builder block, the button for adding it stays greyed out, making it impossible to remove and then re-add a Review Step block (without reloading the page). The same issue also affects buttons for adding different types of message children to Review Step block.

2. In supporting runtimes (i.e., Apros), arrow buttons for navigating between units should be disabled while completing Step Builder blocks; they should become available again when user reaches review step.

**Testing**

For the first issue:

1. Add a Step Builder block to a unit.
2. Add a Review Step block to Step Builder. (Observe that the corresponding button is greyed out.)
3. Remove the Review Step block. Observe that the corresponding button is re-enabled.
4. Click the button to make sure that it is possible to re-add a Review Step to the Step Builder block.
5. Repeat steps 2-5 for the different message types that can be added to Review Step blocks.

For the second issue:

1. Add a unit to a subsection with some existing units.
2. Add a Step Builder block to the unit.
3. Add a couple of Mentoring Step blocks and a Review Step block.
4. Add a question to each Mentoring Step.
5. Complete the block in Apros. Observe that while you are looking at individual steps, the arrow buttons to the left and right of the question(s) are disabled. When you get to the review step, the arrows become clickable.