### PR TITLE
Fix: Don't import all the problem builder blocks when the django app is loaded

### DIFF
--- a/problem_builder/__init__.py
+++ b/problem_builder/__init__.py
@@ -1,9 +1,0 @@
-from .mentoring import MentoringBlock
-from .answer import AnswerBlock, AnswerRecapBlock
-from .choice import ChoiceBlock
-from .dashboard import DashboardBlock
-from .mcq import MCQBlock, RatingBlock
-from .mrq import MRQBlock
-from .message import MentoringMessageBlock
-from .table import MentoringTableBlock, MentoringTableColumn
-from .tip import TipBlock

--- a/problem_builder/tests/integration/base_test.py
+++ b/problem_builder/tests/integration/base_test.py
@@ -24,7 +24,7 @@ from xblockutils.base_test import SeleniumBaseTest
 # Studio adds a url_name property to each XBlock but Workbench doesn't.
 # Since we rely on it, we need to mock url_name support so it can be set via XML and
 # accessed like a normal field.
-from problem_builder import MentoringBlock
+from problem_builder.mentoring import MentoringBlock
 MentoringBlock.url_name = String()
 
 

--- a/problem_builder/tests/integration/test_mcq.py
+++ b/problem_builder/tests/integration/test_mcq.py
@@ -23,7 +23,7 @@
 import ddt
 from mock import patch, Mock
 
-from problem_builder import MentoringBlock
+from problem_builder.mentoring import MentoringBlock
 from .base_test import MentoringBaseTest
 
 

--- a/problem_builder/tests/integration/test_mentoring.py
+++ b/problem_builder/tests/integration/test_mentoring.py
@@ -69,6 +69,6 @@ class MentoringThemeTest(MentoringAssessmentBaseTest):
         ('apros', "#ff0000")
     )
     def test_lms_theme_applied(self, theme, expected_color):
-        with mock.patch("problem_builder.MentoringBlock.get_theme") as patched_theme:
+        with mock.patch("problem_builder.mentoring.MentoringBlock.get_theme") as patched_theme:
             patched_theme.return_value = _get_mentoring_theme_settings(theme)
             self.assert_status_icon_color(expected_color)

--- a/problem_builder/tests/unit/test_mentoring.py
+++ b/problem_builder/tests/unit/test_mentoring.py
@@ -2,8 +2,7 @@ import unittest
 import ddt
 from mock import MagicMock, Mock, patch
 from xblock.field_data import DictFieldData
-from problem_builder import MentoringBlock
-from problem_builder.mentoring import _default_theme_config
+from problem_builder.mentoring import MentoringBlock, _default_theme_config
 
 
 class TestMentoringBlock(unittest.TestCase):

--- a/problem_builder/tests/unit/test_migration.py
+++ b/problem_builder/tests/unit/test_migration.py
@@ -1,5 +1,5 @@
 import copy
-from problem_builder import MentoringBlock
+from problem_builder.mentoring import MentoringBlock
 from mock import MagicMock, Mock
 import unittest
 from xblock.field_data import DictFieldData

--- a/problem_builder/v1/tests/test_upgrade.py
+++ b/problem_builder/v1/tests/test_upgrade.py
@@ -22,7 +22,7 @@ Test that we can upgrade from mentoring v1 to problem builder (v2).
 """
 import ddt
 from lxml import etree
-from problem_builder import MentoringBlock
+from problem_builder.mentoring import MentoringBlock
 from problem_builder.v1.xml_changes import convert_xml_v1_to_v2
 import os.path
 from StringIO import StringIO

--- a/setup.py
+++ b/setup.py
@@ -40,20 +40,20 @@ def package_data(pkg, root_list):
 # Main ##############################################################
 
 BLOCKS = [
-    'problem-builder = problem_builder:MentoringBlock',
+    'problem-builder = problem_builder.mentoring:MentoringBlock',
 
-    'pb-table = problem_builder:MentoringTableBlock',
-    'pb-column = problem_builder:MentoringTableColumn',
-    'pb-answer = problem_builder:AnswerBlock',
-    'pb-answer-recap = problem_builder:AnswerRecapBlock',
-    'pb-mcq = problem_builder:MCQBlock',
-    'pb-rating = problem_builder:RatingBlock',
-    'pb-mrq = problem_builder:MRQBlock',
-    'pb-message = problem_builder:MentoringMessageBlock',
-    'pb-tip = problem_builder:TipBlock',
-    'pb-choice = problem_builder:ChoiceBlock',
+    'pb-table = problem_builder.table:MentoringTableBlock',
+    'pb-column = problem_builder.table:MentoringTableColumn',
+    'pb-answer = problem_builder.answer:AnswerBlock',
+    'pb-answer-recap = problem_builder.answer:AnswerRecapBlock',
+    'pb-mcq = problem_builder.mcq:MCQBlock',
+    'pb-rating = problem_builder.mcq:RatingBlock',
+    'pb-mrq = problem_builder.mrq:MRQBlock',
+    'pb-message = problem_builder.message:MentoringMessageBlock',
+    'pb-tip = problem_builder.tip:TipBlock',
+    'pb-choice = problem_builder.choice:ChoiceBlock',
 
-    'pb-dashboard = problem_builder:DashboardBlock',
+    'pb-dashboard = problem_builder.dashboard:DashboardBlock',
     # Deprecated. You can temporarily uncomment and run 'python setup.py develop' if you have these blocks
     # installed from testing mentoring v2 and need to get past an error message.
     #'mentoring = problem_builder:MentoringBlock',  # Deprecated alias for problem-builder

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,1 +1,2 @@
 -e git+https://github.com/edx/XBlock.git@496d3cb9aca1d9e0a18b0f5e73c7bede824e465f#egg=XBlock
+selenium==2.47.3  # 2.48 is not working atm


### PR DESCRIPTION
OC-1003

This fixes [TNL-3563](https://openedx.atlassian.net/browse/TNL-3563).

The `pb-dashboard` block was not loading due to a bizarre combination of factors, brought into play by the recent [django-rest-framework upgrade](https://github.com/edx/edx-platform/pull/9831).

**Details**:

The error was being reported as:

```
  File "/edx/xblocks/xblock-problem-builder/problem_builder/dashboard.py", line 415, in student_view
    value = sub_api.get_submissions(mcq_submission_key, limit=1)[0]["answer"]
AttributeError: 'NoneType' object has no attribute 'get_submissions'
```

To get the true error, I had to remove a `try: ... except ImportError` wrapper, and then we can see the real cause:

```
Traceback (most recent call last):
  File "manage.py", line 116, in <module>
    execute_from_command_line([sys.argv[0]] + django_args)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 443, in execute_from_command_line
    utility.execute()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 382, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 261, in fetch_command
    klass = load_command_class(app_name, subcommand)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 69, in load_command_class
    module = import_module('%s.management.commands.%s' % (app_name, name))
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/__init__.py", line 2, in <module>
    import contentstore.signals
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/signals.py", line 9, in <module>
    from contentstore.courseware_index import CoursewareSearchIndexer, LibrarySearchIndexer
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/courseware_index.py", line 340, in <module>
    class CoursewareSearchIndexer(SearchIndexerBase):
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/courseware_index.py", line 353, in CoursewareSearchIndexer
    UNNAMED_MODULE_NAME = _("(Unnamed)")
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/translation/__init__.py", line 86, in ugettext
    return _trans.ugettext(message)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/monkey_patch/django_utils_translation.py", line 70, in dont_translate_empty_string
    message = function(message)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/translation/trans_real.py", line 278, in ugettext
    return do_translate(message, 'ugettext')
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/translation/trans_real.py", line 268, in do_translate
    _default = translation(settings.LANGUAGE_CODE)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/translation/trans_real.py", line 183, in translation
    default_translation = _fetch(settings.LANGUAGE_CODE)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/translation/trans_real.py", line 160, in _fetch
    app = import_module(appname)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "/edx/app/edxapp/venvs/edxapp/src/edx-sga/edx_sga/__init__.py", line 1, in <module>
    from .sga import StaffGradedAssignmentXBlock
  File "/edx/app/edxapp/venvs/edxapp/src/edx-sga/edx_sga/sga.py", line 24, in <module>
    from submissions import api as submissions_api
  File "/edx/app/edxapp/venvs/edxapp/src/edx-submissions/submissions/api.py", line 16, in <module>
    from submissions.serializers import (
  File "/edx/app/edxapp/venvs/edxapp/src/edx-submissions/submissions/serializers.py", line 42, in <module>
    class SubmissionSerializer(serializers.ModelSerializer):
  File "/edx/app/edxapp/venvs/edxapp/src/edx-submissions/submissions/serializers.py", line 54, in SubmissionSerializer
    attempt_number = IntegerField(min_value=0)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/rest_framework/fields.py", line 721, in __init__
    message = self.error_messages['min_value'].format(min_value=self.min_value)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/functional.py", line 108, in __wrapper__
    res = func(*self.__args, **self.__kw)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/translation/__init__.py", line 86, in ugettext
    return _trans.ugettext(message)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/monkey_patch/django_utils_translation.py", line 70, in dont_translate_empty_string
    message = function(message)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/translation/trans_real.py", line 278, in ugettext
    return do_translate(message, 'ugettext')
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/translation/trans_real.py", line 268, in do_translate
    _default = translation(settings.LANGUAGE_CODE)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/translation/trans_real.py", line 183, in translation
    default_translation = _fetch(settings.LANGUAGE_CODE)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/translation/trans_real.py", line 160, in _fetch
    app = import_module(appname)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "/edx/xblocks/xblock-problem-builder/problem_builder/__init__.py", line 4, in <module>
    from .dashboard import DashboardBlock
  File "/edx/xblocks/xblock-problem-builder/problem_builder/dashboard.py", line 36, in <module>
    from .mcq import MCQBlock
  File "/edx/xblocks/xblock-problem-builder/problem_builder/mcq.py", line 31, in <module>
    from .sub_api import sub_api, SubmittingXBlockMixin
  File "/edx/xblocks/xblock-problem-builder/problem_builder/sub_api.py", line 25, in <module>
    from submissions import api as sub_api
ImportError: cannot import name api
```

Essentially, two django apps (`cms.djangoapps.contentstore` and `rest_framework`) are calling `ugettext()` at import time (i.e. when the CMS starts up), and as you can see in the trace above, this leads to a circular import of the edx-submissions API.

**Fix**:
A complete fix would probably involve changing `ugettext` to `ugettext_lazy` in any import-time code of all django apps used by the platform, but that is an involved undertaking and can lead to subtle bugs.

So I have worked around the issue by fixing problem-builder so it doesn't load `dashboard.py` when imported as a django app (which was not necessary). This does change the import path for the XBlock, but I'm not aware of any third party code that would be using that import.