### PR TITLE
Allow Videos and images to be added to Mentoring Step Block.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 /workbench.*
 /dist
 /templates
+/var
 *.iml
 .idea/*
+dump.rdb
 problem_builder.tests.*

--- a/problem_builder/step.py
+++ b/problem_builder/step.py
@@ -127,11 +127,27 @@ class MentoringStepBlock(
         NestedXBlockSpec allows explicitly setting disabled/enabled state, disabled reason (if any) and single/multiple
         instances
         """
+        additional_blocks = []
+        try:
+            from xmodule.video_module.video_module import VideoDescriptor
+            additional_blocks.append(NestedXBlockSpec(
+                VideoDescriptor, category='video', label=_(u"Video")
+            ))
+        except ImportError:
+            pass
+        try:
+            from imagemodal import ImageModal
+            additional_blocks.append(NestedXBlockSpec(
+                ImageModal, category='imagemodal', label=_(u"Image Modal")
+            ))
+        except ImportError:
+            pass
+
         return [
             NestedXBlockSpec(AnswerBlock, boilerplate='studio_default'),
             MCQBlock, RatingBlock, MRQBlock, HtmlBlockShim,
             AnswerRecapBlock, MentoringTableBlock,
-        ]
+        ] + additional_blocks
 
     @property
     def has_question(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ddt
 mock
 unicodecsv==0.9.4
--e git+https://github.com/edx/xblock-utils.git@588f7fd3ee88847c57cf09d10e81caa6b267ec51#egg=xblock-utils
+-e git+https://github.com/edx/xblock-utils.git@b4f9b51146c7fafa12f41d54af752b8f1516dffd#egg=xblock-utils
 -e .

--- a/run_tests.py
+++ b/run_tests.py
@@ -24,6 +24,12 @@ if __name__ == "__main__":
     # Configure a range of ports in case the default port of 8081 is in use
     os.environ.setdefault("DJANGO_LIVE_TEST_SERVER_ADDRESS", "localhost:8081-8099")
 
+    try:
+        os.mkdir('var')
+    except OSError:
+        # May already exist.
+        pass
+
     from django.conf import settings
     settings.INSTALLED_APPS += ("problem_builder", )
 


### PR DESCRIPTION
@mtyaka 

Testing instructions:

1. Create a course, add 'step-builder' to the advanced modules.
2. Add step builder block, add Mentoring Step to that block.
3. You should see Video block is available for adding. Add one to see if it works.
4. Stop CMS, install https://github.com/Stanford-Online/xblock-image-modal
5. Go back to Mentoring Step block in the CMS
6. See Image Modal in the available blocks list for adding. Add one to see if it works.