### PR TITLE
Enable seamless use of steps that have no questions.

### DIFF
--- a/problem_builder/answer.py
+++ b/problem_builder/answer.py
@@ -125,6 +125,7 @@ class AnswerBlock(SubmittingXBlockMixin, AnswerMixin, QuestionMixin, StudioEdita
     """
     CATEGORY = 'pb-answer'
     STUDIO_LABEL = _(u"Long Answer")
+    answerable = True
 
     name = String(
         display_name=_("Question ID (name)"),

--- a/problem_builder/public/js/step.js
+++ b/problem_builder/public/js/step.js
@@ -85,6 +85,10 @@ function MentoringStepBlock(runtime, element) {
 
         getStepLabel: function() {
             return $('.sb-step', element).data('next-button-label');
+        },
+
+        hasQuestion: function() {
+            return $('.sb-step', element).data('has-question')
         }
 
     };

--- a/problem_builder/questionnaire.py
+++ b/problem_builder/questionnaire.py
@@ -90,6 +90,7 @@ class QuestionnaireAbstractBlock(
     )
     editable_fields = ('question', 'message', 'weight', 'display_name', 'show_title')
     has_children = True
+    answerable = True
 
     @lazy
     def html_id(self):

--- a/problem_builder/step.py
+++ b/problem_builder/step.py
@@ -133,6 +133,10 @@ class MentoringStepBlock(
             AnswerRecapBlock, MentoringTableBlock,
         ]
 
+    @property
+    def has_question(self):
+        return any(getattr(child, 'answerable', False) for child in self.steps)
+
     @XBlock.json_handler
     def submit(self, submissions, suffix=''):
         log.info(u'Received submissions: {}'.format(submissions))

--- a/problem_builder/templates/html/step.html
+++ b/problem_builder/templates/html/step.html
@@ -1,4 +1,4 @@
-<div class="sb-step" data-next-button-label="{{ self.next_button_label }}">
+<div class="sb-step" data-next-button-label="{{ self.next_button_label }}" {% if self.has_question %} data-has-question="true" {% endif %}>
   {% if show_title %}
   <div class="title">
     <h3>

--- a/problem_builder/tests/integration/test_step_builder.py
+++ b/problem_builder/tests/integration/test_step_builder.py
@@ -211,6 +211,7 @@ class StepBuilderTest(MentoringAssessmentBaseTest):
         # It should be possible to visit the MRQ from here
         self.wait_until_clickable(controls.next_question)
         controls.next_question.click()
+        self.html_section(step_builder, controls)
         self.peek_at_multiple_response_question(
             None, step_builder, controls, extended_feedback=True, alternative_review=True
         )
@@ -229,6 +230,24 @@ class StepBuilderTest(MentoringAssessmentBaseTest):
         step_builder.find_elements_by_css_selector('.correct-list li a')[0].click()
         self.expect_question_visible(None, step_builder)
         self.assertEqual(controls.next_question.get_attribute('value'), "Next Challenge")
+
+    def html_section(self, step_builder, controls, last=False):
+        self.wait_until_hidden(controls.submit)
+        target_control = controls.review if last else controls.next_question
+        self.wait_until_clickable(target_control)
+        target_control.click()
+
+    def test_html_last(self):
+        step_builder, controls = self.load_assessment_scenario("step_builder_html_last.xml")
+        # Step 1
+        # Submit free-form answer, go to next step
+        self.freeform_answer(None, step_builder, controls, 'This is the answer', CORRECT)
+
+        # Step 2
+        # Submit MCQ, go to next step
+        self.single_choice_question(None, step_builder, controls, 'Maybe not', INCORRECT)
+
+        self.html_section(step_builder, controls, last=True)
 
     @data(
         {"max_attempts": 0, "extended_feedback": False},  # Unlimited attempts, no extended feedback
@@ -252,6 +271,9 @@ class StepBuilderTest(MentoringAssessmentBaseTest):
         # Step 3
         # Submit rating, go to next step
         self.rating_question(None, step_builder, controls, "5 - Extremely good", CORRECT)
+
+        # Step 4, html with no question.
+        self.html_section(step_builder, controls)
 
         # Last step
         # Submit MRQ, go to review
@@ -308,6 +330,8 @@ class StepBuilderTest(MentoringAssessmentBaseTest):
         # Submit rating, go to next step
         self.rating_question(None, step_builder, controls, "1 - Not good at all", INCORRECT)
 
+        # Step 4, read only. Go to next step.
+        self.html_section(step_builder, controls)
         # Last step
         # Submit MRQ, go to review
         user_selection = ("Its elegance", "Its beauty", "Its gracefulness")
@@ -350,6 +374,7 @@ class StepBuilderTest(MentoringAssessmentBaseTest):
         self.freeform_answer(None, step_builder, controls, 'This is the answer', CORRECT)
         self.single_choice_question(None, step_builder, controls, 'Maybe not', INCORRECT)
         self.rating_question(None, step_builder, controls, "5 - Extremely good", CORRECT)
+        self.html_section(step_builder, controls)
         self.multiple_response_question(None, step_builder, controls, ("Its beauty",), PARTIAL, last=True)
 
         # The review tips for MCQ 2 and the MRQ should be shown:
@@ -374,6 +399,7 @@ class StepBuilderTest(MentoringAssessmentBaseTest):
         self.single_choice_question(None, step_builder, controls, 'Yes', CORRECT)
         self.rating_question(None, step_builder, controls, "5 - Extremely good", CORRECT)
         user_selection = ("Its elegance", "Its beauty", "Its gracefulness")
+        self.html_section(step_builder, controls)
         self.multiple_response_question(None, step_builder, controls, user_selection, CORRECT, last=True)
 
         # If attempts remain and student got all answers right, show "complete" message
@@ -390,6 +416,7 @@ class StepBuilderTest(MentoringAssessmentBaseTest):
         )
         self.single_choice_question(None, step_builder, controls, 'Maybe not', INCORRECT)
         self.rating_question(None, step_builder, controls, "1 - Not good at all", INCORRECT)
+        self.html_section(step_builder, controls)
         self.multiple_response_question(None, step_builder, controls, ("Its beauty",), PARTIAL, last=True)
 
         # The review tips will not be shown because no attempts remain:

--- a/problem_builder/tests/integration/xml_templates/step_builder.xml
+++ b/problem_builder/tests/integration/xml_templates/step_builder.xml
@@ -36,6 +36,10 @@
     </pb-rating>
   </sb-step>
 
+    <sb-step display_name="Fourth Step">
+        <html_demo>Test test test</html_demo>
+    </sb-step>
+
   <sb-step display_name="Last step">
     <pb-mrq name="mrq_1_1" question="What do you like in this MRQ?" required_choices='["gracefulness","elegance","beauty"]' message="Question Feedback Message">
       <pb-choice value="elegance">Its elegance</pb-choice>

--- a/problem_builder/tests/integration/xml_templates/step_builder_html_last.xml
+++ b/problem_builder/tests/integration/xml_templates/step_builder_html_last.xml
@@ -1,0 +1,26 @@
+<step-builder url_name="step-builder" display_name="Step Builder"
+              max_attempts="1" extended_feedback="True">
+
+  <sb-step display_name="First step" next_button_label="Next Challenge">
+    <pb-answer name="goal" question="What is your goal?" />
+  </sb-step>
+
+  <sb-step display_name="Second step" next_button_label="Next Item">
+    <pb-mcq name="mcq_1_1" question="Do you like this MCQ?" correct_choices='["yes"]'>
+      <pb-choice value="yes">Yes</pb-choice>
+        <pb-choice value="maybenot">Maybe not</pb-choice>
+        <pb-choice value="understand">I don't understand</pb-choice>
+
+        <pb-tip values='["yes"]'>Great!</pb-tip>
+        <pb-tip values='["maybenot"]'>Ah, damn.</pb-tip>
+        <pb-tip values='["understand"]'><div id="test-custom-html">Really?</div></pb-tip>
+    </pb-mcq>
+  </sb-step>
+
+  <sb-step display_name="Last HTML step">
+    <html_demo>Bla bla bla</html_demo>
+  </sb-step>
+
+  <sb-review-step />
+
+</step-builder>


### PR DESCRIPTION
To test:

1. Add 'step-builder' to advanced modules.
2. Create a step builder block.
3. Create a few steps within the step builder block.
4. Fill some with nothing but fluff, others with questions
5. Make sure you can move through the fluff steps without disrupting functionality of the questions
6. Make sure the button semantics make sense-- next or review where appropriate

@e-kolpakov 