### PR TITLE
Fix: Problem Builder does not show on Progress page until student submits an answer (OC-1033)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,13 @@ before_install:
     - "export DISPLAY=:99"
     - "sh -e /etc/init.d/xvfb start"
 install:
-    - "pip install -e git://github.com/edx/xblock-sdk.git#egg=xblock-sdk"
+    - "pip install -e git://github.com/edx/xblock-sdk.git@22c1b2f173919bef22f2d9d9295ec5396d02dffd#egg=xblock-sdk"
     - "pip install -r requirements.txt"
-    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements.txt"
-    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/test-requirements.txt"
+    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"
+    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt"
     - "pip uninstall -y xblock-problem-builder && python setup.py sdist && pip install dist/xblock-problem-builder-2.0.tar.gz"
     - "pip install -r test_requirements.txt"
+    - "mkdir var"
 script:
     - pep8 problem_builder --max-line-length=120
     - pylint problem_builder --disable=all --enable=function-redefined,undefined-variable,unused-variable

--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -221,6 +221,10 @@ class MentoringBlock(XBlock, StepParentMixin, StudioEditableXBlockMixin, StudioC
 
         return Score(score, int(round(score * 100)), correct, incorrect, partially_correct)
 
+    def max_score(self):
+        """ Maximum score. We scale all scores to a maximum of 1.0 so this is always 1.0 """
+        return 1.0
+
     def include_theme_files(self, fragment):
         theme = self.get_theme()
         theme_package, theme_files = theme['package'], theme['locations']


### PR DESCRIPTION
OC-1033

**Fix Description**
Without this fix, Problem Builder blocks do not appear on a student's "Progress" page until the student has submitted a grade. The reason was that Problem Builder did not implement the `max_score()` method.

**Potential Further Improvement**
Problem Builder blocks currently return scores as floating point values between `0` and `1`. It would be better to return integer numerator/denominator pairs (simpler for students, more reliable, more consistent with CAPA modules). However, changing that in the middle of any live course could cause some students' scores to be weighted differently than others. (e.g. Student A could have a score of '0.5/1' while student B could submit the same answer post-upgrade and get a score of '1/2' - which is theoretically the same but would be weighted more heavily when computing the grade of that unit as a whole). 

That said, if the currently live course[s] mostly use problem builder blocks containing only one question each, it would make sense to make that change/fix now.

**Note**
This PR also includes some fixes for the Travis CI build, but those changes do not affect the code itself and are contained to `.travis.yml`