### PR TITLE
Making MCQ use message attribute the same way MRQ does

### DIFF
--- a/problem_builder/mcq.py
+++ b/problem_builder/mcq.py
@@ -99,6 +99,7 @@ class MCQBlock(SubmittingXBlockMixin, QuestionnaireAbstractBlock):
 
         return {
             'submission': submission,
+            'message': self.message,
             'status': 'correct' if correct else 'incorrect',
             'tips': formatted_tips,
             'weight': self.weight,

--- a/problem_builder/public/js/questionnaire.js
+++ b/problem_builder/public/js/questionnaire.js
@@ -1,5 +1,20 @@
 // TODO: Split in two files
 
+function display_message(message, messageView, checkmark){
+    if (message) {
+        var msg = '<div class="message-content">' + message + '</div>' +
+                  '<div class="close icon-remove-sign fa-times-circle"></div>';
+        messageView.showMessage(msg);
+        if (checkmark) {
+            checkmark.addClass('checkmark-clickable');
+            checkmark.on('click', function(ev) {
+                ev.stopPropagation();
+                messageView.showMessage(msg);
+            })
+        }
+    }
+}
+
 function MessageView(element, mentoring) {
     return {
         messageDOM: $('.feedback', element),
@@ -102,12 +117,14 @@ function MCQBlock(runtime, element) {
             $('.choice input', element).prop('disabled', true);
         },
 
-        handleSubmit: function(result) {
+        handleSubmit: function(result, options) {
 
-            mentoring = this.mentoring;
+            var mentoring = this.mentoring;
 
             var messageView = MessageView(element, mentoring);
             messageView.clearResult();
+
+            display_message(result.message, messageView, options.checkmark);
 
             var choiceInputs = $('.choice-selector input', element);
             $.each(choiceInputs, function(index, choiceInput) {
@@ -127,7 +144,6 @@ function MCQBlock(runtime, element) {
 
                 if (result.tips && choiceInputDOM.val() === result.submission) {
                     mentoring.setContent(choiceTipsDOM, result.tips);
-                    messageView.showMessage(choiceTipsDOM);
                 }
 
                 choiceResultDOM.off('click').on('click', function() {
@@ -187,22 +203,11 @@ function MRQBlock(runtime, element) {
 
         handleSubmit: function(result, options) {
 
-            mentoring = this.mentoring;
+            var mentoring = this.mentoring;
 
             var messageView = MessageView(element, mentoring);
 
-            if (result.message) {
-                var msg = '<div class="message-content">' + result.message + '</div>' +
-                          '<div class="close icon-remove-sign fa-times-circle"></div>';
-                messageView.showMessage(msg);
-                if (options.checkmark) {
-                    options.checkmark.addClass('checkmark-clickable');
-                    options.checkmark.on('click', function(ev) {
-                        ev.stopPropagation();
-                        messageView.showMessage(msg);
-                    })
-                }
-            }
+            display_message(result.message, messageView, options.checkmark);
 
             var questionnaireDOM = $('fieldset.questionnaire', element);
             var data = questionnaireDOM.data();

--- a/problem_builder/tests/integration/base_test.py
+++ b/problem_builder/tests/integration/base_test.py
@@ -17,6 +17,7 @@
 # along with this program in a file in the toplevel directory called
 # "AGPLv3".  If not, see <http://www.gnu.org/licenses/>.
 #
+import mock
 
 from xblock.fields import String
 from xblockutils.base_test import SeleniumBaseTest, SeleniumXBlockTest
@@ -98,6 +99,22 @@ class ProblemBuilderBaseTest(SeleniumXBlockTest, PopupCheckMixin):
 class MentoringBaseTest(SeleniumBaseTest, PopupCheckMixin):
     module_name = __name__
     default_css_selector = 'div.mentoring'
+
+    __asides_patch = None
+
+    @classmethod
+    def setUpClass(cls):
+        super(MentoringBaseTest, cls).setUpClass()
+        cls.__asides_patch = mock.patch(
+            "workbench.runtime.WorkbenchRuntime.applicable_aside_types",
+            mock.Mock(return_value=[])
+        )
+        cls.__asides_patch.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.__asides_patch.stop()
+        super(MentoringBaseTest, cls).tearDownClass()
 
 
 class MentoringAssessmentBaseTest(ProblemBuilderBaseTest):

--- a/problem_builder/tests/integration/test_mentoring.py
+++ b/problem_builder/tests/integration/test_mentoring.py
@@ -149,7 +149,7 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
 
     def _standard_checks(self, answer, mcq, mrq, rating, messages):
         self.assertEqual(answer.get_attribute('value'), 'This is the answer')
-        self._assert_feedback_showed(mcq, 0, "Great!")
+        self._assert_feedback_showed(mcq, 0, "Great!", click_choice_result=True)
         self._assert_feedback_showed(
             mrq, 0, "This is something everyone has to like about this MRQ",
             click_choice_result=True
@@ -234,7 +234,7 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
 
         # precondition - verifying 100% score achieved
         self.assertEqual(answer.get_attribute('value'), 'This is the answer')
-        self._assert_feedback_showed(mcq, 0, "Great!")
+        self._assert_feedback_showed(mcq, 0, "Great!", click_choice_result=True)
         self._assert_feedback_showed(
             mrq, 0, "This is something everyone has to like about this MRQ",
             click_choice_result=True
@@ -275,7 +275,7 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
 
         def assert_state(answer, mcq, mrq, rating, messages):
             self.assertEqual(answer.get_attribute('value'), 'This is the answer')
-            self._assert_feedback_showed(mcq, 0, "Great!")
+            self._assert_feedback_showed(mcq, 0, "Great!", click_choice_result=True)
             self._assert_feedback_showed(
                 mrq, 0, "This is something everyone has to like about this MRQ",
                 click_choice_result=True

--- a/problem_builder/tests/integration/xml/mcq_1.xml
+++ b/problem_builder/tests/integration/xml/mcq_1.xml
@@ -1,6 +1,6 @@
 <vertical_demo>
     <problem-builder url_name="mcq_1" enforce_dependency="false">
-        <pb-mcq name="mcq_1_1" question="Do you like this MCQ?" correct_choices='["yes"]'>
+        <pb-mcq name="mcq_1_1" question="Do you like this MCQ?" correct_choices='["yes"]' message="Feedback message 1">
             <pb-choice value="yes">Yes</pb-choice>
             <pb-choice value="maybenot">Maybe not</pb-choice>
             <pb-choice value="understand">I don't understand</pb-choice>
@@ -10,7 +10,9 @@
             <pb-tip values='["understand"]'><div id="test-custom-html">Really?</div></pb-tip>
         </pb-mcq>
 
-        <pb-rating name="mcq_1_2" low="Not good at all" high="Extremely good" question="How do you rate this MCQ?" correct_choices='["4","5"]'>
+        <pb-rating name="mcq_1_2" low="Not good at all" high="Extremely good" question="How do you rate this MCQ?"
+                   correct_choices='["4","5"]' message="Feedback message 2"
+            >
             <pb-choice value="notwant">I don't want to rate it</pb-choice>
 
             <pb-tip values='["4","5"]'>I love good grades.</pb-tip>


### PR DESCRIPTION
**Description:** MCQ and MRQ were inconsistent in terms of showing feedback: 
* MRQ provided both per-choice feedback and question-level feedback, 
* MCQ, depsite having "message" attribute, only provided per-choice feedback.

**Testing instructions:**
1. Create problem builder/step builder with MCQ and MRQ.
2. Fill in "Message" fields for both MCQ and MRQ
3. Provide choices and (optional) tips
4. Open PB/SB in LMS/Apros
5. Answer MRQ. Observe that when feedback is displayed, question-level feedback is shown first, per-choice feedback is available by clicking on correctness icons next to choices
6. Answer MCQ. Observe that the behavior is now the same (i.e. message from "Message" attribute is shown first, per-choice feedback is available by clicking on correctness icon)

If you can't see the feedback you might want to turn PB into normal mode (no longer supported in studio edit; use existing PB or update in mongo manually), or enable extended feedback and exhaust all the available attempts.