### PR TITLE
Fix a few layout issues in Step Builder

### DIFF
--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -1124,10 +1124,6 @@ class MentoringWithExplicitStepsBlock(BaseMentoringBlock, StudioContainerWithNes
         """
         Add some HTML to the author view that allows authors to add child blocks.
         """
-        context['wrap_children'] = {
-            'head': u'<div class="mentoring">',
-            'tail': u'</div>'
-        }
         fragment = super(MentoringWithExplicitStepsBlock, self).author_edit_view(context)
         fragment.add_content(loader.render_template('templates/html/mentoring_url_name.html', {
             "url_name": self.url_name

--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -501,7 +501,7 @@ class MentoringBlock(BaseMentoringBlock, StudioContainerXBlockMixin, StepParentM
                 # The student got this wrong. Check if there is a review tip to show.
                 tip_html = child.get_review_tip()
                 if tip_html:
-                    if hasattr(self.runtime, 'replace_jump_to_id_urls'):
+                    if getattr(self.runtime, 'replace_jump_to_id_urls', None) is not None:
                         tip_html = self.runtime.replace_jump_to_id_urls(tip_html)
                     review_tips.append(tip_html)
         return review_tips

--- a/problem_builder/mixins.py
+++ b/problem_builder/mixins.py
@@ -106,7 +106,7 @@ class MessageParentMixin(object):
                 child = self.runtime.get_block(child_id)
                 if child.type == message_type:
                     content = child.content
-                    if hasattr(self.runtime, 'replace_jump_to_id_urls'):
+                    if getattr(self.runtime, 'replace_jump_to_id_urls', None) is not None:
                         content = self.runtime.replace_jump_to_id_urls(content)
                     return content
         if or_default:

--- a/problem_builder/plot.py
+++ b/problem_builder/plot.py
@@ -350,10 +350,6 @@ class PlotBlock(StudioEditableXBlockMixin, StudioContainerWithNestedXBlocksMixin
         """
         Add some HTML to the author view that allows authors to add child blocks.
         """
-        context['wrap_children'] = {
-            'head': u'<div class="mentoring">',
-            'tail': u'</div>'
-        }
         fragment = super(PlotBlock, self).author_edit_view(context)
         fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/problem-builder-edit.css'))
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/util.js'))

--- a/problem_builder/public/css/problem-builder.css
+++ b/problem_builder/public/css/problem-builder.css
@@ -174,6 +174,7 @@
     list-style: none;
     padding-left: 0 !important;
     margin-left: 0;
+    margin-bottom: 0.4em;
 }
 .mentoring .review-list li {
     display: inline;
@@ -184,7 +185,7 @@
 }
 
 .mentoring .results-section {
-    margin-left: 40px;
+    margin-left: 50px;
 }
 
 .mentoring .results-section p {
@@ -202,21 +203,21 @@
     display: none;
 }
 
-.mentoring .assessment-review-tips p.review-tips-intro {
+.mentoring p.review-tips-intro {
     margin-top: 1.2em;
     margin-bottom: 0;
     font-weight: bold;
 }
 
-.mentoring .assessment-review-tips .review-tips-list {
+.mentoring .review-tips-list {
     margin-top: 0;
     padding-top: 0;
 }
-.mentoring .assessment-review-tips .review-tips-list li {
+.mentoring .review-tips-list li {
     margin-left: 0.5em;
     padding-left: 0;
 }
-.mentoring .assessment-review-tips .review-tips-list li p {
+.mentoring .review-tips-list li p {
     display: inline;
     margin: 0;
 }

--- a/problem_builder/public/js/container_edit.js
+++ b/problem_builder/public/js/container_edit.js
@@ -9,4 +9,9 @@ function ProblemBuilderContainerEdit(runtime, element) {
     if (window.ProblemBuilderUtil) {
         ProblemBuilderUtil.transformClarifications(element);
     }
+
+    // Add a "mentoring" class to the root XBlock so we can use it as a
+    // selector. We cannot just add a div.mentoring wrapper around our children
+    // since it breaks jQuery drag-and-drop re-ordering of children.
+    $(".wrapper-xblock.level-page > .xblock-render > .xblock").addClass("mentoring");
 }

--- a/problem_builder/public/themes/apros.css
+++ b/problem_builder/public/themes/apros.css
@@ -17,7 +17,12 @@
     text-transform: uppercase;
 }
 
-.themed-xblock.mentoring .assessment-review-tips .review-tips-list li {
+.themed-xblock.mentoring .sb-review-score {
+    margin-left: 40px;
+    margin-top: 15px;
+}
+
+.themed-xblock.mentoring .review-tips-list li {
     margin-left: 1.8em;
     padding-left: 0;
 }

--- a/problem_builder/step.py
+++ b/problem_builder/step.py
@@ -212,10 +212,6 @@ class MentoringStepBlock(
         Add some HTML to the author view that allows authors to add child blocks.
         """
         local_context = dict(context)
-        local_context['wrap_children'] = {
-            'head': u'<div class="mentoring">',
-            'tail': u'</div>'
-        }
         local_context['author_edit_view'] = True
         fragment = super(MentoringStepBlock, self).author_edit_view(local_context)
         fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/problem-builder.css'))

--- a/problem_builder/step_review.py
+++ b/problem_builder/step_review.py
@@ -285,10 +285,6 @@ class ReviewStepBlock(
         """
         Add some HTML to the author view that allows authors to add child blocks.
         """
-        context['wrap_children'] = {
-            'head': u'<div class="mentoring">',
-            'tail': u'</div>'
-        }
         fragment = super(ReviewStepBlock, self).author_edit_view(context)
         fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/problem-builder.css'))
         fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/problem-builder-edit.css'))

--- a/problem_builder/templates/html/mentoring_with_steps.html
+++ b/problem_builder/templates/html/mentoring_with_steps.html
@@ -14,7 +14,7 @@
     {% endfor %}
 
     <div class="submit">
-      <span class="step-overall-checkmark fa icon-2x"></span>
+      <span class="step-overall-checkmark fa icon-2x fa-fw"></span>
       <input type="button" class="input-main" value="Submit" disabled="disabled" />
       <input type="button" class="input-next" value="Next Step" disabled="disabled" />
       <input type="button" class="input-review" value="Review grade" disabled="disabled" />

--- a/problem_builder/templates/html/sb-review-score.html
+++ b/problem_builder/templates/html/sb-review-score.html
@@ -9,7 +9,7 @@
     <hr/>
 
 
-    <span class="assessment-checkmark icon-2x checkmark-correct icon-ok fa fa-check"></span>
+    <span class="assessment-checkmark icon-2x checkmark-correct icon-ok fa fa-check fa-fw"></span>
     <div class="results-section">
       <p>
         {% blocktrans count correct_answers=correct_answers %}
@@ -32,7 +32,7 @@
     <div class="clear"></div>
 
 
-    <span class="assessment-checkmark icon-2x checkmark-partially-correct icon-ok fa fa-check"></span>
+    <span class="assessment-checkmark icon-2x checkmark-partially-correct icon-ok fa fa-check fa-fw"></span>
     <div class="results-section">
       <p>
         {% blocktrans count partially_correct_answers=partially_correct_answers %}
@@ -55,7 +55,7 @@
     <div class="clear"></div>
 
 
-    <span class="assessment-checkmark icon-2x checkmark-incorrect icon-exclamation fa fa-exclamation"></span>
+    <span class="assessment-checkmark icon-2x checkmark-incorrect icon-exclamation fa fa-exclamation fa-fw"></span>
     <div class="results-section">
       <p>
         {% blocktrans count incorrect_answers=incorrect_answers %}


### PR DESCRIPTION
This PR fixes the following issues:
* In some Step Builder components, you were unable to change the order of child blocks in Studio (drag-to-reorder was broken). This is due to Studio using a selector that requires the child XBlocks to be direct children of the parent XBlock, with no intermediate elements such as a DIV
* Fixed a minor issue causing mentoring v2 blocks in legacy assessment mode to be broken when tested in Studio.
* Fixed the layout issues in MCKIN-3626
* Added a feature so you can move messages below the "Try Again" button if you want to. To do so, simply do not add a "Per Question Review Tips" block to the review step.

Screenshot of block after fixing layout issues:
![screen shot 2015-11-05 at 10 24 50 pm](https://cloud.githubusercontent.com/assets/945577/10990814/1b3f53a8-840c-11e5-8e8d-ce29dbf40b1d.png)

Screenshot of block with no per question review step configured:
![screen shot 2015-11-05 at 10 32 55 pm](https://cloud.githubusercontent.com/assets/945577/10991206/58c79e48-8410-11e5-8559-ecddfd01b070.png)
