### PR TITLE
Step Builder: Explain review links to users

### DIFF
--- a/problem_builder/templates/html/sb-review-score.html
+++ b/problem_builder/templates/html/sb-review-score.html
@@ -3,6 +3,11 @@
 <div class="sb-review-score">
   <div class="grade-result">
     <h2>{% blocktrans %}You scored {{score}}% on this assessment. {% endblocktrans %}</h2>
+    {% if show_extended_review %}
+      <p class="review-links-explanation">
+        {% trans "Click a question to review feedback on your response." %}
+      </p>
+    {% endif %}
     {% if is_example %}
       <p><em>{% trans "Note: This is an example score, to show how the review step will look." %}</em></p>
     {% endif %}


### PR DESCRIPTION
This PR adds a message explaining how to use review links to the "Score Summary" block that can be added to the "Review Step" of a Step Builder exercise.

**Additional info**

- The message is shown if review links are present, and hidden otherwise.
- The wording of the message follows the spec in [MCKIN-3682](https://edx-wiki.atlassian.net/browse/MCKIN-3682).

**Screenshots**

LMS:

![review-links-message-lms](https://cloud.githubusercontent.com/assets/961441/11964659/8297d7de-a8ef-11e5-9ca9-904b847e1ed8.png)

Apros:

![review-links-message-apros](https://cloud.githubusercontent.com/assets/961441/11964663/894bfd30-a8ef-11e5-84f3-231f12b361ad.png)

**Testing**

1. Add Step Builder block to a unit.
2. Add a Mentoring Step and a Review Step to the Step Builder block.
3. Add one or more questions to the Mentoring Step.
4. Add a Score Summary to the Review Step.
5. Set "Max. attempts allowed" to 1 for the Step Builder block.
6. Set "Extended feedback" to "True".
7. Publish.
8. Complete the block in the LMS. Review step should match screenshot above (i.e., it should show review links for individual questions and message explaining how to use them).
9. In Studio, set "Extended feedback" to "False" and re-publish.
10. Refresh the page in the LMS. Review step should not show review link, and message explaining how to use review links should be hidden.
