### PR TITLE
Create Django migrations, deprecate South.

### DIFF
--- a/problem_builder/migrations/0001_initial.py
+++ b/problem_builder/migrations/0001_initial.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Answer',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=50, db_index=True)),
+                ('student_id', models.CharField(max_length=32, db_index=True)),
+                ('course_id', models.CharField(max_length=50, db_index=True)),
+                ('student_input', models.TextField(default=b'', blank=True)),
+                ('created_on', models.DateTimeField(auto_now_add=True, verbose_name=b'created on')),
+                ('modified_on', models.DateTimeField(auto_now=True, verbose_name=b'modified on')),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='answer',
+            unique_together=set([('student_id', 'course_id', 'name')]),
+        ),
+    ]


### PR DESCRIPTION
Background: Adds Django 1.8 migrations to Problem Builder. The hope is to get this merged into dogwood. Otherwise any installations which use Problem Builder will have to run an extra management command to make their migration data accurate.

@nedbat This is the PR I was talking about. Will we be able to get someone from Platform to give it a look over? @itsjeyd This is ready for you to review-- if you could check it over when you start your day/before I start mine, that would be helpful.

How to test:

1. In MySQL: `CREATE DATABASE edxapp2;GRANT ALL ON edxapp2.* TO 'edxapp001'@'localhost';`
2. Change `cms.auth.json` and `lms.auth.json` to point to the new db, 'edxapp2'.
3. `paver update_db --settings=devstack`
4. Register a new 'staff' user.
5. Lookup and set is_staff on the user via the Django shell. Save it.
6. Create a Course with problem builder in it, with a long answer component.
7. Save, test the long answer component, navigate away, return, verify long answer still has the given text.