### PR TITLE
Fix exponential rerendering after hitting next button too many times.

### DIFF
--- a/problem_builder/public/js/mentoring_with_steps.js
+++ b/problem_builder/public/js/mentoring_with_steps.js
@@ -160,6 +160,7 @@ function MentoringWithStepsBlock(runtime, element) {
             updateNextLabel();
 
             // Reinstate default event handlers
+            nextDOM.off('click');
             nextDOM.on('click', updateDisplay);
             reviewButtonDOM.on('click', showGrade);
 


### PR DESCRIPTION
After each tap of the 'next' button, the updateDisplay function would be called and apply itself to the next button again, causing exponential rendering runs which would freeze things up after a certain number of questions.

@e-kolpakov This one's a critical hotfix. Please look at it first opportunity, if you can, so we can deploy it Monday.