### PR TITLE
OC-1387 Always show tooltips feedback if tips are present.

### DIFF
--- a/problem_builder/mcq.py
+++ b/problem_builder/mcq.py
@@ -51,6 +51,16 @@ class MCQBlock(SubmittingXBlockMixin, QuestionnaireAbstractBlock):
     CATEGORY = 'pb-mcq'
     STUDIO_LABEL = _(u"Multiple Choice Question")
 
+    message = String(
+        display_name=_("Message"),
+        help=_(
+            "General feedback provided when submitting. "
+            "(This is not shown if there is a more specific feedback tip for the choice selected by the learner.)"
+        ),
+        scope=Scope.content,
+        default=""
+    )
+
     student_choice = String(
         # {Last input submitted by the student
         default="",
@@ -64,7 +74,7 @@ class MCQBlock(SubmittingXBlockMixin, QuestionnaireAbstractBlock):
         list_values_provider=QuestionnaireAbstractBlock.choice_values_provider,
         list_style='set',  # Underered, unique items. Affects the UI editor.
     )
-    editable_fields = QuestionnaireAbstractBlock.editable_fields + ('correct_choices', )
+    editable_fields = QuestionnaireAbstractBlock.editable_fields + ('message', 'correct_choices', )
 
     def describe_choice_correctness(self, choice_value):
         if choice_value in self.correct_choices:

--- a/problem_builder/mrq.py
+++ b/problem_builder/mrq.py
@@ -22,7 +22,7 @@
 
 import logging
 
-from xblock.fields import List, Scope, Boolean
+from xblock.fields import List, Scope, Boolean, String
 from xblock.validation import ValidationMessage
 from .questionnaire import QuestionnaireAbstractBlock
 from xblockutils.resources import ResourceLoader
@@ -70,6 +70,12 @@ class MRQBlock(QuestionnaireAbstractBlock):
         list_values_provider=QuestionnaireAbstractBlock.choice_values_provider,
         list_style='set',  # Underered, unique items. Affects the UI editor.
         default=[],
+    )
+    message = String(
+        display_name=_("Message"),
+        help=_("General feedback provided when submitting"),
+        scope=Scope.content,
+        default=""
     )
     hide_results = Boolean(display_name="Hide results", scope=Scope.content, default=False)
     editable_fields = (

--- a/problem_builder/public/js/questionnaire.js
+++ b/problem_builder/public/js/questionnaire.js
@@ -123,43 +123,30 @@ function MCQBlock(runtime, element) {
 
             var messageView = MessageView(element, mentoring);
 
-            if (result.message) {
-                var msg = '<div class="message-content">' + result.message + '</div>' +
-                          '<div class="close icon-remove-sign fa-times-circle"></div>';
-                messageView.showMessage(msg);
-            } else { messageView.clearResult(); }
+            messageView.clearResult();
 
-            display_message(result.message, messageView, options.checkmark);
+            var choiceInputDOM = $('.choice-selector input[value="'+ result.submission +'"]');
+            var choiceDOM = choiceInputDOM.closest('.choice');
+            var choiceResultDOM = $('.choice-result', choiceDOM);
+            var choiceTipsDOM = $('.choice-tips', choiceDOM);
 
-            var choiceInputs = $('.choice-selector input', element);
-            $.each(choiceInputs, function(index, choiceInput) {
-                var choiceInputDOM = $(choiceInput);
-                var choiceDOM = choiceInputDOM.closest('.choice');
-                var choiceResultDOM = $('.choice-result', choiceDOM);
-                var choiceTipsDOM = $('.choice-tips', choiceDOM);
-
-                if (choiceInputDOM.prop('checked')) {  // We're showing previous answers,
-                                                       // so go ahead and display results as well
-                    if (result.status === "correct" && choiceInputDOM.val() === result.submission) {
-                        choiceDOM.addClass('correct');
-                        choiceResultDOM.addClass('checkmark-correct icon-ok fa-check');
-                    }
-                    else if (choiceInputDOM.val() === result.submission || _.isNull(result.submission)) {
-                        choiceDOM.addClass('incorrect');
-                        choiceResultDOM.addClass('checkmark-incorrect icon-exclamation fa-exclamation');
-                    }
-
-                    if (result.tips && choiceInputDOM.val() === result.submission) {
-                        mentoring.setContent(choiceTipsDOM, result.tips);
-                    }
-
-                    choiceResultDOM.off('click').on('click', function() {
-                        if (choiceTipsDOM.html() !== '') {
-                            messageView.showMessage(choiceTipsDOM);
-                        }
-                    });
+            // We're showing previous answers, so go ahead and display results as well
+            if (choiceInputDOM.prop('checked')) {
+                display_message(result.message, messageView, options.checkmark);
+                if (result.status === "correct") {
+                    choiceInputDOM.addClass('correct');
+                    choiceResultDOM.addClass('checkmark-correct icon-ok fa-check');
+                } else {
+                    choiceDOM.addClass('incorrect');
+                    choiceResultDOM.addClass('checkmark-incorrect icon-exclamation fa-exclamation');
                 }
-            });
+
+                if (result.tips) {
+                    mentoring.setContent(choiceTipsDOM, result.tips);
+                    messageView.showMessage(choiceTipsDOM);
+                }
+            }
+
 
             if (_.isNull(result.submission)) {
                 messageView.showMessage('<div class="message-content">You have not provided an answer.</div>' +

--- a/problem_builder/questionnaire.py
+++ b/problem_builder/questionnaire.py
@@ -68,13 +68,8 @@ class QuestionnaireAbstractBlock(
         default="",
         multiline_editor=True,
     )
-    message = String(
-        display_name=_("Message"),
-        help=_("General feedback provided when submiting"),
-        scope=Scope.content,
-        default=""
-    )
-    editable_fields = ('question', 'message', 'weight', 'display_name', 'show_title')
+
+    editable_fields = ('question', 'weight', 'display_name', 'show_title')
     has_children = True
     answerable = True
 

--- a/problem_builder/tests/integration/base_test.py
+++ b/problem_builder/tests/integration/base_test.py
@@ -63,24 +63,7 @@ class PopupCheckMixin(object):
             self.assertFalse(item_feedback_popup.is_displayed())
 
 
-class ScrollToMixin(object):
-
-    def scroll_to(self, component, offset=100):
-        """
-        Scrolls browser viewport so component is visible. In rare cases you might
-        need to provide an offset, which will change position by some amount
-        of pixels.
-        :return:
-        """
-        self.browser.execute_script(
-                "return window.scrollTo(0, arguments[0]);",
-                component.location['y']+offset)
-        self.browser.execute_script(
-                "return window.scrollTo(0, arguments[0]);",
-                component.location['y']-offset)
-
-
-class ProblemBuilderBaseTest(SeleniumXBlockTest, PopupCheckMixin, ScrollToMixin):
+class ProblemBuilderBaseTest(SeleniumXBlockTest, PopupCheckMixin):
     """
     The new base class for integration tests.
     Scenarios can be loaded and edited on the fly.
@@ -96,6 +79,12 @@ class ProblemBuilderBaseTest(SeleniumXBlockTest, PopupCheckMixin, ScrollToMixin)
         self.set_scenario_xml(scenario)
         if load_immediately:
             return self.go_to_view("student_view")
+
+    def go_to_view(self, view_name):
+        """ Eliminate errors that come from the Workbench banner overlapping elements """
+        element = super(ProblemBuilderBaseTest, self).go_to_view(view_name)
+        self.browser.execute_script('document.querySelectorAll("header.banner")[0].style.display="none";')
+        return element
 
     def click_submit(self, mentoring):
         """ Click the submit button and wait for the response """
@@ -118,6 +107,12 @@ class MentoringBaseTest(SeleniumBaseTest, PopupCheckMixin):
     default_css_selector = 'div.mentoring'
 
     __asides_patch = None
+
+    def go_to_page(self, page_title, **kwargs):
+        """ Eliminate errors that come from the Workbench banner overlapping elements """
+        element = super(MentoringBaseTest, self).go_to_page(page_title, **kwargs)
+        self.browser.execute_script('document.querySelectorAll("header.banner")[0].style.display="none";')
+        return element
 
     @classmethod
     def setUpClass(cls):

--- a/problem_builder/tests/integration/base_test.py
+++ b/problem_builder/tests/integration/base_test.py
@@ -63,7 +63,24 @@ class PopupCheckMixin(object):
             self.assertFalse(item_feedback_popup.is_displayed())
 
 
-class ProblemBuilderBaseTest(SeleniumXBlockTest, PopupCheckMixin):
+class ScrollToMixin(object):
+
+    def scroll_to(self, component, offset=100):
+        """
+        Scrolls browser viewport so component is visible. In rare cases you might
+        need to provide an offset, which will change position by some amount
+        of pixels.
+        :return:
+        """
+        self.browser.execute_script(
+                "return window.scrollTo(0, arguments[0]);",
+                component.location['y']+offset)
+        self.browser.execute_script(
+                "return window.scrollTo(0, arguments[0]);",
+                component.location['y']-offset)
+
+
+class ProblemBuilderBaseTest(SeleniumXBlockTest, PopupCheckMixin, ScrollToMixin):
     """
     The new base class for integration tests.
     Scenarios can be loaded and edited on the fly.

--- a/problem_builder/tests/integration/test_answer.py
+++ b/problem_builder/tests/integration/test_answer.py
@@ -40,8 +40,6 @@ class AnswerBlockTest(MentoringBaseTest):
 
         # Another answer with the same name
         mentoring = self.go_to_page('Answer Edit 1')
-        header1 = self.browser.find_element_by_css_selector('h1')
-        self.assertEqual(header1.text, 'XBlock: Answer Edit 1')
 
         # Check <html> child
         p = mentoring.find_element_by_css_selector('p')

--- a/problem_builder/tests/integration/test_assessment.py
+++ b/problem_builder/tests/integration/test_assessment.py
@@ -53,7 +53,7 @@ class MentoringAssessmentTest(MentoringAssessmentBaseTest):
         self.browser.get(self.live_server_url)
 
     def freeform_answer(self, number, mentoring, controls, text_input, result, saved_value="", last=False):
-        question = self.expect_question_visible(number, mentoring)
+        self.expect_question_visible(number, mentoring)
         self.assert_persistent_elements_present(mentoring)
         self._selenium_bug_workaround_scroll_to(mentoring, question)
 
@@ -112,7 +112,7 @@ class MentoringAssessmentTest(MentoringAssessmentBaseTest):
         self.do_post(controls, last)
 
     def rating_question(self, number, mentoring, controls, choice_name, result, last=False):
-        question = self.expect_question_visible(number, mentoring)
+        self.expect_question_visible(number, mentoring)
         self.assert_persistent_elements_present(mentoring)
         self._selenium_bug_workaround_scroll_to(mentoring, question)
         self.assertIn("How much do you rate this MCQ?", mentoring.text)

--- a/problem_builder/tests/integration/test_assessment.py
+++ b/problem_builder/tests/integration/test_assessment.py
@@ -23,28 +23,6 @@ from .base_test import CORRECT, INCORRECT, PARTIAL, MentoringAssessmentBaseTest,
 
 @ddt
 class MentoringAssessmentTest(MentoringAssessmentBaseTest):
-    def _selenium_bug_workaround_scroll_to(self, mentoring, question):
-        """Workaround for selenium bug:
-
-        Some version of Selenium has a bug that prevents scrolling
-        to radiobuttons before being clicked. The click not taking
-        place, when it's outside the view.
-
-        Since the bug does not affect other content, asking Selenium
-        to click on the legend first, will properly scroll it.
-
-        It also have it's fair share of issues with the workbench header.
-
-        For this reason we click on the bottom-most element, scrolling to it.
-        Then, click on the title of the question (also scrolling to it)
-        hopefully, this gives us enough room for the full step with the
-        control buttons to fit.
-        """
-        controls = mentoring.find_element_by_css_selector("div.submit")
-        title = question.find_element_by_css_selector("h3.question-title")
-        controls.click()
-        title.click()
-
     def assert_persistent_elements_present(self, mentoring):
         self.assertIn("A Simple Assessment", mentoring.text)
         self.assertIn("This paragraph is shared between all questions.", mentoring.text)
@@ -55,7 +33,6 @@ class MentoringAssessmentTest(MentoringAssessmentBaseTest):
     def freeform_answer(self, number, mentoring, controls, text_input, result, saved_value="", last=False):
         self.expect_question_visible(number, mentoring)
         self.assert_persistent_elements_present(mentoring)
-        self._selenium_bug_workaround_scroll_to(mentoring, question)
 
         answer = mentoring.find_element_by_css_selector("textarea.answer.editable")
 
@@ -114,7 +91,6 @@ class MentoringAssessmentTest(MentoringAssessmentBaseTest):
     def rating_question(self, number, mentoring, controls, choice_name, result, last=False):
         self.expect_question_visible(number, mentoring)
         self.assert_persistent_elements_present(mentoring)
-        self._selenium_bug_workaround_scroll_to(mentoring, question)
         self.assertIn("How much do you rate this MCQ?", mentoring.text)
 
         self.assert_disabled(controls.submit)

--- a/problem_builder/tests/integration/test_mentoring.py
+++ b/problem_builder/tests/integration/test_mentoring.py
@@ -137,16 +137,12 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
         self.assertFalse(choice_input.is_selected())
 
     def _standard_filling(self, answer, mcq, mrq, rating):
-        self.scroll_to(answer)
         answer.send_keys('This is the answer')
-        self.scroll_to(mcq)
         self.click_choice(mcq, "Yes")
         # 1st, 3rd and 4th options, first three are correct, i.e. two mistakes: 2nd and 4th
-        self.scroll_to(mrq, 300)
         self.click_choice(mrq, "Its elegance")
         self.click_choice(mrq, "Its gracefulness")
         self.click_choice(mrq, "Its bugs")
-        self.scroll_to(rating)
         self.click_choice(rating, "4")
 
     # mcq and rating can't be reset easily, but it's not required; listing them here to keep method signature similar
@@ -157,11 +153,8 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
                 checkbox.click()
 
     def _standard_checks(self, answer, mcq, mrq, rating, messages):
-        self.scroll_to(answer)
         self.assertEqual(answer.get_attribute('value'), 'This is the answer')
-        self.scroll_to(mcq)
         self._assert_feedback_showed(mcq, 0, "Great!", click_choice_result=True)
-        self.scroll_to(mrq, 300)
         self._assert_feedback_showed(
             mrq, 0, "This is something everyone has to like about this MRQ",
             click_choice_result=True
@@ -172,23 +165,18 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
         )
         self._assert_feedback_showed(mrq, 2, "This MRQ is indeed very graceful", click_choice_result=True)
         self._assert_feedback_showed(mrq, 3, "Nah, there aren't any!", click_choice_result=True, success=False)
-        self.scroll_to(rating)
         self._assert_feedback_showed(rating, 3, "I love good grades.", click_choice_result=True)
         self.assertTrue(messages.is_displayed())
-        self.scroll_to(messages)
         self.assertEqual(messages.text, "FEEDBACK\nNot done yet")
 
     def _feedback_customized_checks(self, answer, mcq, mrq, rating, messages):
         # Long answer: Previous answer and feedback visible
-        self.scroll_to(answer)
         self.assertEqual(answer.get_attribute('value'), 'This is the answer')
         # MCQ: Previous answer and feedback hidden
-        self.scroll_to(mcq)
         for i in range(3):
             self._assert_feedback_hidden(mcq, i)
             self._assert_not_checked(mcq, i)
         # MRQ: Previous answer and feedback visible
-        self.scroll_to(mrq, 300)
         self._assert_feedback_showed(
             mrq, 0, "This is something everyone has to like about this MRQ",
             click_choice_result=True
@@ -200,13 +188,11 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
         self._assert_feedback_showed(mrq, 2, "This MRQ is indeed very graceful", click_choice_result=True)
         self._assert_feedback_showed(mrq, 3, "Nah, there aren't any!", click_choice_result=True, success=False)
         # Rating: Previous answer and feedback hidden
-        self.scroll_to(rating)
         for i in range(5):
             self._assert_feedback_hidden(rating, i)
             self._assert_not_checked(rating, i)
         # Messages
         self.assertTrue(messages.is_displayed())
-        self.scroll_to(messages)
         self.assertEqual(messages.text, "FEEDBACK\nNot done yet")
 
     def reload_student_view(self):
@@ -285,11 +271,8 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
             self.assertFalse(submit.is_enabled())
 
             # ... until student answers MCQs again
-            self.scroll_to(mcq)
             self.click_choice(mcq, "Maybe not")
-            self.scroll_to(rating)
             self.click_choice(rating, "2")
-            self.scroll_to(submit)
             self.assertTrue(submit.is_enabled())
 
     def test_given_perfect_score_in_past_loads_current_result(self):

--- a/problem_builder/tests/integration/test_questionnaire.py
+++ b/problem_builder/tests/integration/test_questionnaire.py
@@ -32,19 +32,6 @@ from .base_test import MentoringBaseTest
 
 @ddt.ddt
 class QuestionnaireBlockTest(MentoringBaseTest):
-
-    def _selenium_bug_workaround_scroll_to(self, mcq_legend):
-        """Workaround for selenium bug:
-
-        Some version of Selenium has a bug that prevents scrolling
-        to radiobuttons before being clicked. The click not taking
-        place, when it's outside the view.
-
-        Since the bug does not affect other content, asking Selenium
-        to click on the legend first, will properly scroll it.
-        """
-        mcq_legend.click()
-
     def _get_choice_label_text(self, choice):
         return choice.find_element_by_css_selector('label').text
 
@@ -104,7 +91,6 @@ class QuestionnaireBlockTest(MentoringBaseTest):
                 mcq1_answer, mcq2_answer, item_feedback1, item_feedback2,
                 feedback1_selector=".choice-tips .tip p",
                 feedback2_selector=".choice-tips .tip p"):
-            self._selenium_bug_workaround_scroll_to(mcq1)
 
             mcq1_choices_input[mcq1_answer].click()
             mcq2_choices_input[mcq2_answer].click()
@@ -125,7 +111,6 @@ class QuestionnaireBlockTest(MentoringBaseTest):
         self.assertFalse(submit.is_enabled())
 
         # Submit button stays disabled when there are unfinished mcqs
-        self._selenium_bug_workaround_scroll_to(mcq1)
         mcq1_choices_input[1].click()
         self.assertFalse(submit.is_enabled())
 
@@ -244,7 +229,6 @@ class QuestionnaireBlockTest(MentoringBaseTest):
         self.assertFalse(submit.is_enabled())
 
         inputs = choices_list.find_elements_by_css_selector('.choice-selector input')
-        self._selenium_bug_workaround_scroll_to(choices_list)
         inputs[0].click()
         inputs[1].click()
         inputs[2].click()

--- a/problem_builder/tests/integration/test_titles.py
+++ b/problem_builder/tests/integration/test_titles.py
@@ -72,7 +72,7 @@ class StepTitlesTest(SeleniumXBlockTest):
     )
 
     mcq_template = """
-        <problem-builder mode="{{mode}}">
+        <problem-builder mode="{mode}">
             <pb-mcq name="mcq_1_1" question="Who was your favorite character?"
               correct_choices="[gaius,adama,starbuck,roslin,six,lee]"
               {display_name_attr} {show_title_attr}
@@ -88,7 +88,7 @@ class StepTitlesTest(SeleniumXBlockTest):
     """
 
     mrq_template = """
-        <problem-builder mode="{{mode}}">
+        <problem-builder mode="{mode}">
             <pb-mrq name="mrq_1_1" question="What makes a great MRQ?"
               ignored_choices="[1,2,3]"
               {display_name_attr} {show_title_attr}
@@ -101,7 +101,7 @@ class StepTitlesTest(SeleniumXBlockTest):
     """
 
     rating_template = """
-        <problem-builder mode="{{mode}}">
+        <problem-builder mode="{mode}">
             <pb-rating name="rating_1_1" question="How do you rate Battlestar Galactica?"
               correct_choices="[5,6]"
               {display_name_attr} {show_title_attr}
@@ -112,7 +112,7 @@ class StepTitlesTest(SeleniumXBlockTest):
     """
 
     long_answer_template = """
-        <problem-builder mode="{{mode}}">
+        <problem-builder mode="{mode}">
             <pb-answer name="answer_1_1" question="What did you think of the ending?"
               {display_name_attr} {show_title_attr} />
         </problem-builder>

--- a/problem_builder/tests/integration/xml/mcq_1.xml
+++ b/problem_builder/tests/integration/xml/mcq_1.xml
@@ -6,7 +6,6 @@
             <pb-choice value="understand">I don't understand</pb-choice>
 
             <pb-tip values='["yes"]'>Great!</pb-tip>
-            <pb-tip values='["maybenot"]'>Ah, damn.</pb-tip>
             <pb-tip values='["understand"]'><div id="test-custom-html">Really?</div></pb-tip>
         </pb-mcq>
 
@@ -17,7 +16,6 @@
 
             <pb-tip values='["4","5"]'>I love good grades.</pb-tip>
             <pb-tip values='["1","2","3"]'>Will do better next time...</pb-tip>
-            <pb-tip values='["notwant"]'>Your loss!</pb-tip>
         </pb-rating>
 
         <pb-message type="completed">

--- a/problem_builder/tests/integration/xml_templates/feedback_persistence_mcq_no_tips.xml
+++ b/problem_builder/tests/integration/xml_templates/feedback_persistence_mcq_no_tips.xml
@@ -1,0 +1,11 @@
+<vertical_demo>
+    <problem-builder url_name="feedback_tips" enforce_dependency="false">
+
+        <pb-mcq name="feedback_mcq_2" question="Do you like this MCQ?" correct_choices='["yes"]' message="Question level Feedback">
+            <pb-choice value="yes">Yes</pb-choice>
+            <pb-choice value="maybenot">Maybe not</pb-choice>
+            <pb-choice value="understand">I don't understand</pb-choice>
+        </pb-mcq>
+
+    </problem-builder>
+</vertical_demo>

--- a/problem_builder/tests/integration/xml_templates/feedback_persistence_mcq_tips.xml
+++ b/problem_builder/tests/integration/xml_templates/feedback_persistence_mcq_tips.xml
@@ -1,0 +1,15 @@
+<vertical_demo>
+    <problem-builder url_name="feedback_no_tips" enforce_dependency="false">
+
+        <pb-mcq name="feedback_mcq_2" question="Do you like this MCQ?" correct_choices='["yes"]'>
+            <pb-choice value="yes">Yes</pb-choice>
+            <pb-choice value="maybenot">Maybe not</pb-choice>
+            <pb-choice value="understand">I don't understand</pb-choice>
+
+            <pb-tip values='["yes"]'>Great!</pb-tip>
+            <pb-tip values='["maybenot"]'>Ah, damn.</pb-tip>
+            <pb-tip values='["understand"]'><div id="test-custom-html">Really?</div></pb-tip>
+        </pb-mcq>
+
+    </problem-builder>
+</vertical_demo>


### PR DESCRIPTION
Testing instructions: 

# Problem Builder 

## MRQ 

Create following MRQ block, and verify that behavior is unchanged: 

1.That when you create submit you get question feedback: "Thank you for answering!" 
2. And after clicking check-mark you get tooltip. 

```
<problem-builder display_name="Default Title" weight="1" mode="standard">
    <html_demo>
        <p>Please answer the questions below.</p>
    </html_demo>

    <pb-mrq name="mrq_1_1" question="What do you like in this MRQ?" message="Thank you for answering!" required_choices='["gracefulness","elegance","beauty"]'>
        <pb-choice value="elegance">Its elegance</pb-choice>
        <pb-choice value="beauty">Its beauty</pb-choice>
        <pb-choice value="gracefulness">Its gracefulness</pb-choice>
        <pb-choice value="bugs">Its bugs</pb-choice>

        <pb-tip values='["gracefulness"]'>This MRQ is indeed very graceful</pb-tip>
        <pb-tip values='["bugs"]'>Nah, there aren't any!</pb-tip>
    </pb-mrq>

    <pb-message type="completed">
        <p>Congratulations!</p>
    </pb-message>
    <pb-message type="incomplete">
        <p>Still some work to do...</p>
    </pb-message>
</problem-builder>
```


## MCQ

Create following MCQ block, and verify that behavior is changed.

1. When you select a,b or d you get a tooltip straight away 
2. When you select c you get question level feedback


```
<vertical_demo>
    <html_demo><h1>Problem Builder Demo</h1></html_demo>

    <problem-builder display_name="MCQ With Tips" weight="1" mode="standard">
        <html_demo>
            <p>Like the MRQ above, multiple choice and rating questions can also provide feedback based on which answer was selected and whether the answer is correct or not. Here's an example:</p>
        </html_demo>

        <pb-mcq name="subjunctive"
          message="This is question level feedback"
          question="Which sentence correctly uses the subjunctive case?" correct_choices='["d"]'>
            <pb-choice value="a">To buy or not to buy, that is the question.</pb-choice>
            <pb-choice value="b">Renting gives you more flexibility.</pb-choice>
            <pb-choice value="c">If I was you, I'd buy the house.</pb-choice>
            <pb-choice value="d">If I were you, I'd rent the house.</pb-choice>
            <pb-tip values='["a","b"]'>This sentence is not discussing hypotheticals or impossibilities.</pb-tip>
            <pb-tip values='["d"]'>Correct. "was" has become "were" to indicate the subjunctive case.</pb-tip>
        </pb-mcq>

        <pb-message type="incomplete">
            <p>Read the tip above and try again.</p>
        </pb-message>

        <pb-message type="completed">
            <p>Nicely done. If I were you, I'd be proud of myself.</p>
        </pb-message>
    </problem-builder>
    
    <html_demo>
        <h1>See the details</h1>
        <p>Check out the XML source below to get an idea of how these mentoring questions were set up and what kind of options authors have available.</p>
    </html_demo>
</vertical_demo>
```

## Step Builder

It is not affected AFAIK, as doesn't display tooltips at all, and can optionally display question level feedback messages (on the review block). 