### PR TITLE
Problem Builder: Add instance-wide option to hide previous answers for MCQs

### DIFF
--- a/problem_builder/public/js/mentoring.js
+++ b/problem_builder/public/js/mentoring.js
@@ -8,7 +8,9 @@ function MentoringBlock(runtime, element) {
     var attemptsTemplate = _.template($('#xblock-attempts-template').html());
     var data = $('.mentoring', element).data();
     var children = runtime.children(element);
-    var steps = runtime.children(element).filter(function(c) { return c.element.className.indexOf('assessment_step_view') > -1; });
+    var steps = runtime.children(element).filter(function(c) {
+        return $(c.element).attr("class").indexOf('assessment_step_view') > -1;
+    });
     var step = data.step;
 
     var mentoring = {

--- a/problem_builder/public/js/questionnaire.js
+++ b/problem_builder/public/js/questionnaire.js
@@ -122,7 +122,7 @@ function MCQBlock(runtime, element) {
             var mentoring = this.mentoring;
 
             var messageView = MessageView(element, mentoring);
-            
+
             if (result.message) {
                 var msg = '<div class="message-content">' + result.message + '</div>' +
                           '<div class="close icon-remove-sign fa-times-circle"></div>';
@@ -138,24 +138,27 @@ function MCQBlock(runtime, element) {
                 var choiceResultDOM = $('.choice-result', choiceDOM);
                 var choiceTipsDOM = $('.choice-tips', choiceDOM);
 
-                if (result.status === "correct" && choiceInputDOM.val() === result.submission) {
-                    choiceDOM.addClass('correct');
-                    choiceResultDOM.addClass('checkmark-correct icon-ok fa-check');
-                }
-                else if (choiceInputDOM.val() === result.submission || _.isNull(result.submission)) {
-                    choiceDOM.addClass('incorrect');
-                    choiceResultDOM.addClass('checkmark-incorrect icon-exclamation fa-exclamation');
-                }
-
-                if (result.tips && choiceInputDOM.val() === result.submission) {
-                    mentoring.setContent(choiceTipsDOM, result.tips);
-                }
-
-                choiceResultDOM.off('click').on('click', function() {
-                    if (choiceTipsDOM.html() !== '') {
-                        messageView.showMessage(choiceTipsDOM);
+                if (choiceInputDOM.prop('checked')) {  // We're showing previous answers,
+                                                       // so go ahead and display results as well
+                    if (result.status === "correct" && choiceInputDOM.val() === result.submission) {
+                        choiceDOM.addClass('correct');
+                        choiceResultDOM.addClass('checkmark-correct icon-ok fa-check');
                     }
-                });
+                    else if (choiceInputDOM.val() === result.submission || _.isNull(result.submission)) {
+                        choiceDOM.addClass('incorrect');
+                        choiceResultDOM.addClass('checkmark-incorrect icon-exclamation fa-exclamation');
+                    }
+
+                    if (result.tips && choiceInputDOM.val() === result.submission) {
+                        mentoring.setContent(choiceTipsDOM, result.tips);
+                    }
+
+                    choiceResultDOM.off('click').on('click', function() {
+                        if (choiceTipsDOM.html() !== '') {
+                            messageView.showMessage(choiceTipsDOM);
+                        }
+                    });
+                }
             });
 
             if (_.isNull(result.submission)) {

--- a/problem_builder/tests/integration/test_mentoring.py
+++ b/problem_builder/tests/integration/test_mentoring.py
@@ -131,6 +131,11 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
         self.assertNotIn('checkmark-correct', choice_result_classes)
         self.assertNotIn('checkmark-incorrect', choice_result_classes)
 
+    def _assert_not_checked(self, questionnaire, choice_index):
+        choice = self._get_choice(questionnaire, choice_index)
+        choice_input = choice.find_element_by_css_selector('input')
+        self.assertFalse(choice_input.is_selected())
+
     def _standard_filling(self, answer, mcq, mrq, rating):
         answer.send_keys('This is the answer')
         self.click_choice(mcq, "Yes")
@@ -161,6 +166,32 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
         self._assert_feedback_showed(mrq, 2, "This MRQ is indeed very graceful", click_choice_result=True)
         self._assert_feedback_showed(mrq, 3, "Nah, there aren't any!", click_choice_result=True, success=False)
         self._assert_feedback_showed(rating, 3, "I love good grades.", click_choice_result=True)
+        self.assertTrue(messages.is_displayed())
+        self.assertEqual(messages.text, "FEEDBACK\nNot done yet")
+
+    def _feedback_customized_checks(self, answer, mcq, mrq, rating, messages):
+        # Long answer: Previous answer and feedback visible
+        self.assertEqual(answer.get_attribute('value'), 'This is the answer')
+        # MCQ: Previous answer and feedback hidden
+        for i in range(3):
+            self._assert_feedback_hidden(mcq, i)
+            self._assert_not_checked(mcq, i)
+        # MRQ: Previous answer and feedback visible
+        self._assert_feedback_showed(
+            mrq, 0, "This is something everyone has to like about this MRQ",
+            click_choice_result=True
+        )
+        self._assert_feedback_showed(
+            mrq, 1, "This is something everyone has to like about beauty",
+            click_choice_result=True, success=False
+        )
+        self._assert_feedback_showed(mrq, 2, "This MRQ is indeed very graceful", click_choice_result=True)
+        self._assert_feedback_showed(mrq, 3, "Nah, there aren't any!", click_choice_result=True, success=False)
+        # Rating: Previous answer and feedback hidden
+        for i in range(5):
+            self._assert_feedback_hidden(rating, i)
+            self._assert_not_checked(rating, i)
+        # Messages
         self.assertTrue(messages.is_displayed())
         self.assertEqual(messages.text, "FEEDBACK\nNot done yet")
 
@@ -217,6 +248,33 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
         # ...until some changes are done
         self.click_choice(mrq, "Its elegance")
         self.assertTrue(submit.is_enabled())
+
+    def test_does_not_persist_mcq_feedback_on_page_reload_if_disabled(self):
+        with mock.patch("problem_builder.mentoring.MentoringBlock.get_options") as patched_options:
+            patched_options.return_value = {'pb_mcq_hide_previous_answer': True}
+            mentoring = self.load_scenario("feedback_persistence.xml")
+            answer, mcq, mrq, rating = self._get_controls(mentoring)
+            messages = self._get_messages_element(mentoring)
+
+            self._standard_filling(answer, mcq, mrq, rating)
+            self.click_submit(mentoring)
+            self._standard_checks(answer, mcq, mrq, rating, messages)
+
+            # now, reload the page and see if previous answers and results for MCQs are hidden
+            mentoring = self.reload_student_view()
+            answer, mcq, mrq, rating = self._get_controls(mentoring)
+            messages = self._get_messages_element(mentoring)
+            submit = mentoring.find_element_by_css_selector('.submit input.input-main')
+
+            self._feedback_customized_checks(answer, mcq, mrq, rating, messages)
+
+            # after reloading submit is disabled...
+            self.assertFalse(submit.is_enabled())
+
+            # ... until student answers MCQs again
+            self.click_choice(mcq, "Maybe not")
+            self.click_choice(rating, "2")
+            self.assertTrue(submit.is_enabled())
 
     def test_given_perfect_score_in_past_loads_current_result(self):
         mentoring = self.load_scenario("feedback_persistence.xml")

--- a/problem_builder/tests/integration/test_mentoring.py
+++ b/problem_builder/tests/integration/test_mentoring.py
@@ -267,7 +267,6 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
             submit = mentoring.find_element_by_css_selector('.submit input.input-main')
 
             self._feedback_customized_checks(answer, mcq, mrq, rating, messages)
-
             # after reloading submit is disabled...
             self.assertFalse(submit.is_enabled())
 

--- a/problem_builder/tests/integration/test_titles.py
+++ b/problem_builder/tests/integration/test_titles.py
@@ -74,7 +74,7 @@ class StepTitlesTest(SeleniumXBlockTest):
     mcq_template = """
         <problem-builder mode="{{mode}}">
             <pb-mcq name="mcq_1_1" question="Who was your favorite character?"
-              correct_choices="gaius,adama,starbuck,roslin,six,lee"
+              correct_choices="[gaius,adama,starbuck,roslin,six,lee]"
               {display_name_attr} {show_title_attr}
             >
                 <pb-choice value="gaius">Gaius Baltar</pb-choice>
@@ -90,7 +90,7 @@ class StepTitlesTest(SeleniumXBlockTest):
     mrq_template = """
         <problem-builder mode="{{mode}}">
             <pb-mrq name="mrq_1_1" question="What makes a great MRQ?"
-              ignored_choices="1,2,3"
+              ignored_choices="[1,2,3]"
               {display_name_attr} {show_title_attr}
             >
                 <pb-choice value="1">Lots of choices</pb-choice>
@@ -103,7 +103,7 @@ class StepTitlesTest(SeleniumXBlockTest):
     rating_template = """
         <problem-builder mode="{{mode}}">
             <pb-rating name="rating_1_1" question="How do you rate Battlestar Galactica?"
-              correct_choices="5,6"
+              correct_choices="[5,6]"
               {display_name_attr} {show_title_attr}
             >
                 <pb-choice value="6">More than 5 stars</pb-choice>

--- a/problem_builder/tests/unit/test_problem_builder.py
+++ b/problem_builder/tests/unit/test_problem_builder.py
@@ -1,9 +1,15 @@
-import unittest
 import ddt
+import unittest
+
 from mock import MagicMock, Mock, patch
+from random import random
+
 from xblock.field_data import DictFieldData
+
 from problem_builder.mcq import MCQBlock
-from problem_builder.mentoring import MentoringBlock, MentoringMessageBlock, _default_theme_config
+from problem_builder.mentoring import (
+    MentoringBlock, MentoringMessageBlock, _default_theme_config, _default_options_config
+)
 
 
 @ddt.ddt
@@ -64,45 +70,79 @@ class TestMentoringBlock(unittest.TestCase):
 
 
 @ddt.ddt
-class TestMentoringBlockTheming(unittest.TestCase):
+class TestMentoringBlockSettings(unittest.TestCase):
+
+    DEFAULT_SETTINGS = {
+        'get_theme': _default_theme_config,
+        'get_options': _default_options_config,
+    }
+
+    SETTINGS_KEYS = {
+        'get_theme': MentoringBlock.theme_key,
+        'get_options': MentoringBlock.options_key,
+    }
+
     def setUp(self):
         self.service_mock = Mock()
         self.runtime_mock = Mock()
         self.runtime_mock.service = Mock(return_value=self.service_mock)
         self.block = MentoringBlock(self.runtime_mock, DictFieldData({}), Mock())
 
-    def test_theme_uses_default_theme_if_settings_service_is_not_available(self):
-        self.runtime_mock.service = Mock(return_value=None)
-        self.assertEqual(self.block.get_theme(), _default_theme_config)
+    def test_settings_method_returns_default_if_settings_service_is_not_available(self):
+        for settings_method, default_config in self.DEFAULT_SETTINGS.items():
+            self.runtime_mock.service = Mock(return_value=None)
+            self.assertEqual(getattr(self.block, settings_method)(), default_config)
 
-    def test_theme_uses_default_theme_if_no_theme_is_set(self):
-        self.service_mock.get_settings_bucket = Mock(return_value=None)
-        self.assertEqual(self.block.get_theme(), _default_theme_config)
-        self.service_mock.get_settings_bucket.assert_called_once_with(self.block)
+    def test_settings_method_returns_default_if_settings_not_customized(self):
+        for settings_method, default_config in self.DEFAULT_SETTINGS.items():
+            self.service_mock.get_settings_bucket = Mock(return_value=None)
+            self.assertEqual(getattr(self.block, settings_method)(), default_config)
+            self.service_mock.get_settings_bucket.assert_called_once_with(self.block)
 
     @ddt.data(123, object())
-    def test_theme_raises_if_theme_object_is_not_iterable(self, theme_config):
-        self.service_mock.get_settings_bucket = Mock(return_value=theme_config)
-        with self.assertRaises(TypeError):
-            self.block.get_theme()
-        self.service_mock.get_settings_bucket.assert_called_once_with(self.block)
+    def test_settings_method_raises_if_settings_not_iterable(self, config):
+        for settings_method in self.DEFAULT_SETTINGS:
+            self.service_mock.get_settings_bucket = Mock(return_value=config)
+            with self.assertRaises(TypeError):
+                getattr(self.block, settings_method)()
+            self.service_mock.get_settings_bucket.assert_called_once_with(self.block)
 
     @ddt.data(
         {}, {'mass': 123}, {'spin': {}}, {'parity': "1"}
     )
-    def test_theme_uses_default_theme_if_no_mentoring_theme_is_set_up(self, theme_config):
-        self.service_mock.get_settings_bucket = Mock(return_value=theme_config)
-        self.assertEqual(self.block.get_theme(), _default_theme_config)
-        self.service_mock.get_settings_bucket.assert_called_once_with(self.block)
+    def test_settings_method_returns_default_if_target_setting_not_customized(self, config):
+        for settings_method, default_config in self.DEFAULT_SETTINGS.items():
+            self.service_mock.get_settings_bucket = Mock(return_value=config)
+            self.assertEqual(getattr(self.block, settings_method)(), default_config)
+            self.service_mock.get_settings_bucket.assert_called_once_with(self.block)
 
     @ddt.data(
-        {MentoringBlock.theme_key: 123},
-        {MentoringBlock.theme_key: [1, 2, 3]},
-        {MentoringBlock.theme_key: {'package': 'qwerty', 'locations': ['something_else.css']}},
+        {
+            MentoringBlock.theme_key: 123,
+            MentoringBlock.options_key: 123,
+        },
+        {
+            MentoringBlock.theme_key: [1, 2, 3],
+            MentoringBlock.options_key: [1, 2, 3],
+        },
+        {
+            MentoringBlock.theme_key: {'package': 'qwerty', 'locations': ['something_else.css']},
+            MentoringBlock.options_key: {'pb_mcq_hide_previous_answer': False},
+        },
     )
-    def test_theme_correctly_returns_configured_theme(self, theme_config):
-        self.service_mock.get_settings_bucket = Mock(return_value=theme_config)
-        self.assertEqual(self.block.get_theme(), theme_config[MentoringBlock.theme_key])
+    def test_settings_method_correctly_returns_customized_settings(self, config):
+        for settings_method, settings_key in self.SETTINGS_KEYS.items():
+            self.service_mock.get_settings_bucket = Mock(return_value=config)
+            self.assertEqual(getattr(self.block, settings_method)(), config[settings_key])
+
+
+@ddt.ddt
+class TestMentoringBlockTheming(unittest.TestCase):
+    def setUp(self):
+        self.service_mock = Mock()
+        self.runtime_mock = Mock()
+        self.runtime_mock.service = Mock(return_value=self.service_mock)
+        self.block = MentoringBlock(self.runtime_mock, DictFieldData({}), Mock())
 
     def test_theme_files_are_loaded_from_correct_package(self):
         fragment = MagicMock()
@@ -131,14 +171,39 @@ class TestMentoringBlockTheming(unittest.TestCase):
             self.assertEqual(patched_load_unicode.call_count, len(locations))
 
     def test_student_view_calls_include_theme_files(self):
+        self.service_mock.get_settings_bucket = Mock(return_value={})
         with patch.object(self.block, 'include_theme_files') as patched_include_theme_files:
             fragment = self.block.student_view({})
             patched_include_theme_files.assert_called_with(fragment)
 
     def test_author_preview_view_calls_include_theme_files(self):
+        self.service_mock.get_settings_bucket = Mock(return_value={})
         with patch.object(self.block, 'include_theme_files') as patched_include_theme_files:
             fragment = self.block.author_preview_view({})
             patched_include_theme_files.assert_called_with(fragment)
+
+
+@ddt.ddt
+class TestMentoringBlockOptions(unittest.TestCase):
+    def setUp(self):
+        self.service_mock = Mock()
+        self.runtime_mock = Mock()
+        self.runtime_mock.service = Mock(return_value=self.service_mock)
+        self.block = MentoringBlock(self.runtime_mock, DictFieldData({}), Mock())
+
+    def test_get_option(self):
+        random_key, random_value = random(), random()
+        with patch.object(self.block, 'get_options') as patched_get_options:
+            patched_get_options.return_value = {random_key: random_value}
+            option = self.block.get_option(random_key)
+            patched_get_options.assert_called_once_with()
+            self.assertEqual(option, random_value)
+
+    def test_student_view_calls_get_option(self):
+        self.service_mock.get_settings_bucket = Mock(return_value={})
+        with patch.object(self.block, 'get_option') as patched_get_option:
+            self.block.student_view({})
+            patched_get_option.assert_called_with('pb_mcq_hide_previous_answer')
 
 
 class TestMentoringBlockJumpToIds(unittest.TestCase):


### PR DESCRIPTION
This PR introduces an instance-wide option to hide previous answers (and feedback) for MCQs in Problem Builder. When this option is enabled, students will still receive per-question feedback after providing answers to MCQs and submitting the containing block, but that feedback will not be visible when they return to the block, and all choices for a given MCQ will be unchecked.

**Screenshots: LMS**

Default settings:

![lms-pb-option-disabled](https://cloud.githubusercontent.com/assets/961441/13337547/48901d84-dc1c-11e5-90ff-26c88dfbe76c.png)

Previous answers hidden:

![lms-pb-option-enabled](https://cloud.githubusercontent.com/assets/961441/13337558/56c0ef5a-dc1c-11e5-90f5-55cad42cba1c.png)

---

**Screenshots: Apros**

Default settings:

![apros-pb-option-disabled](https://cloud.githubusercontent.com/assets/961441/13337560/602d782e-dc1c-11e5-86b2-489b89f94c62.png)

Previous  answers hidden:

![apros-pb-option-enabled](https://cloud.githubusercontent.com/assets/961441/13337566/678d15de-dc1c-11e5-94dd-6a40f4dd852b.png)

**Test instructions**

1. Create a subsection with two units and add a Problem Builder block to each one.

2. Add a long answer, MCQ, Rating, MRQ, and Slider to one of the Problem Builder blocks.

3. Publish the units.

4. In LMS/Apros, provide answers to all questions and click "Submit".

5. Navigate to the other unit, then come back to the first unit. Observe that Problem Builder shows previous answers and feedback for all questions.

6. In `lms.env.json`, enable the new option by modifying the `XBLOCK_SETTINGS` for `mentoring`:

   ```js
        "mentoring": {
            "theme": {
                // ...
            },
            "options": {
                "pb_mcq_hide_previous_answer": true
            }
        },
   ```

7. Restart LMS/Apros and reload the page showing the first unit. Observe that Problem Builder does not show previous answers and feedback for MCQs.
