### PR TITLE
Ensure default theme is used if theme has not been customized

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ test:
   override:
     - "if [ $CIRCLE_NODE_INDEX = '0' ]; then pep8 problem_builder --max-line-length=120; fi":
         parallel: true
-    - "if [ $CIRCLE_NODE_INDEX = '1' ]; then pylint problem_builder --disable=all --enable=function-redefined,undefined-variable,unused-variable; fi":
+    - "if [ $CIRCLE_NODE_INDEX = '1' ]; then pylint problem_builder --disable=all --enable=function-redefined,undefined-variable,unused-import,unused-variable; fi":
         parallel: true
     - "python run_tests.py":
         parallel: true

--- a/problem_builder/answer.py
+++ b/problem_builder/answer.py
@@ -26,7 +26,7 @@ from lazy import lazy
 from .models import Answer
 
 from xblock.core import XBlock
-from xblock.fields import Scope, Float, Integer, String
+from xblock.fields import Scope, Integer, String
 from xblock.fragment import Fragment
 from xblock.validation import ValidationMessage
 from xblockutils.resources import ResourceLoader

--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -59,11 +59,6 @@ except ImportError:
 log = logging.getLogger(__name__)
 loader = ResourceLoader(__name__)
 
-_default_theme_config = {
-    'package': 'problem_builder',
-    'locations': ['public/themes/lms.css']
-}
-
 _default_options_config = {
     'pb_mcq_hide_previous_answer': False
 }
@@ -126,8 +121,12 @@ class BaseMentoringBlock(
 
     icon_class = 'problem'
     block_settings_key = 'mentoring'
-    theme_key = 'theme'
     options_key = 'options'
+
+    default_theme_config = {
+        'package': 'problem_builder',
+        'locations': ['public/themes/lms.css']
+    }
 
     @property
     def url_name(self):
@@ -170,7 +169,7 @@ class BaseMentoringBlock(
         Fall back on default options if xblock settings have not been customized at all
         or no customizations for options available.
         """
-        xblock_settings = self.get_xblock_settings(_default_options_config)
+        xblock_settings = self.get_xblock_settings(default={})
         if xblock_settings and self.options_key in xblock_settings:
             return xblock_settings[self.options_key]
         return _default_options_config

--- a/problem_builder/south_migrations/0003_auto__add_share__add_unique_share_shared_by_shared_with_block_id.py
+++ b/problem_builder/south_migrations/0003_auto__add_share__add_unique_share_shared_by_shared_with_block_id.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-from south.utils import datetime_utils as datetime
 from south.db import db
 from south.v2 import SchemaMigration
-from django.db import models
 
 
 class Migration(SchemaMigration):

--- a/problem_builder/table.py
+++ b/problem_builder/table.py
@@ -26,7 +26,7 @@ from django.contrib.auth.models import User
 
 from xblock.core import XBlock
 from xblock.exceptions import JsonHandlerError
-from xblock.fields import Scope, String, Boolean, Dict
+from xblock.fields import Scope, String, Boolean
 from xblock.fragment import Fragment
 
 from xblockutils.resources import ResourceLoader

--- a/problem_builder/tests/integration/test_assessment.py
+++ b/problem_builder/tests/integration/test_assessment.py
@@ -17,7 +17,7 @@
 # along with this program in a file in the toplevel directory called
 # "AGPLv3".  If not, see <http://www.gnu.org/licenses/>.
 #
-from ddt import ddt, unpack, data
+from ddt import ddt, data
 from .base_test import CORRECT, INCORRECT, PARTIAL, MentoringAssessmentBaseTest, GetChoices
 
 

--- a/problem_builder/tests/integration/test_author_changes.py
+++ b/problem_builder/tests/integration/test_author_changes.py
@@ -3,8 +3,8 @@ If an author makes changes to the block after students have started using it, wi
 happen?
 """
 import time
+
 from .base_test import ProblemBuilderBaseTest, MentoringAssessmentBaseTest
-import re
 
 
 class AuthorChangesTest(ProblemBuilderBaseTest):

--- a/problem_builder/tests/integration/test_dashboard.py
+++ b/problem_builder/tests/integration/test_dashboard.py
@@ -21,7 +21,6 @@ from textwrap import dedent
 from mock import Mock, patch
 from .base_test import ProblemBuilderBaseTest
 from selenium.common.exceptions import NoSuchElementException
-from xblockutils.resources import ResourceLoader
 
 
 class MockSubmissionsAPI(object):

--- a/problem_builder/tests/unit/test_dashboard_visual.py
+++ b/problem_builder/tests/unit/test_dashboard_visual.py
@@ -1,10 +1,9 @@
 """
 Unit tests for DashboardVisualData
 """
-from problem_builder.dashboard_visual import DashboardVisualData
-from mock import MagicMock, Mock
 import unittest
-from xblock.field_data import DictFieldData
+
+from problem_builder.dashboard_visual import DashboardVisualData
 
 
 class TestDashboardVisualData(unittest.TestCase):


### PR DESCRIPTION
Follows up on #102.

**Test instructions**

1. Remove theme settings from `lms.envs.json`.
2. Access unit containing Problem Builder block and check if rules in `public/themes/lms.css` are applied. For example, `.choice-result` should have `display: table-cell` (first rule in `public/themes/lms.css`).