### PR TITLE
Problem Builder: Add instance-wide option to hide global feedback and results for Long Answer blocks

### DIFF
--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -60,7 +60,8 @@ log = logging.getLogger(__name__)
 loader = ResourceLoader(__name__)
 
 _default_options_config = {
-    'pb_mcq_hide_previous_answer': False
+    'pb_mcq_hide_previous_answer': False,
+    'pb_hide_feedback_if_attempts_remain': False,
 }
 
 
@@ -174,11 +175,11 @@ class BaseMentoringBlock(
             return xblock_settings[self.options_key]
         return _default_options_config
 
-    def get_option(self, option):
+    def get_option(self, option, default=False):
         """
         Get value of a specific instance-wide `option`.
         """
-        return self.get_options()[option]
+        return self.get_options().get(option, default)
 
     @XBlock.json_handler
     def view(self, data, suffix=''):
@@ -563,9 +564,10 @@ class MentoringBlock(BaseMentoringBlock, StudioContainerXBlockMixin, StepParentM
         """
         results = []
         completed = True
-        show_message = bool(self.student_results)
+        hide_feedback = self.get_option("pb_hide_feedback_if_attempts_remain") and not self.max_attempts_reached
+        show_message = (not hide_feedback) and bool(self.student_results)
 
-        # In standard mode, all children is visible simultaneously, so need collecting responses from all of them
+        # In standard mode, all children are visible simultaneously, so need to collect results for all of them
         for child in self.steps:
             child_result = child.get_last_result()
             results.append([child.name, child_result])

--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -175,11 +175,11 @@ class BaseMentoringBlock(
             return xblock_settings[self.options_key]
         return _default_options_config
 
-    def get_option(self, option, default=False):
+    def get_option(self, option):
         """
         Get value of a specific instance-wide `option`.
         """
-        return self.get_options().get(option, default)
+        return self.get_options().get(option)
 
     @XBlock.json_handler
     def view(self, data, suffix=''):

--- a/problem_builder/public/js/answer.js
+++ b/problem_builder/public/js/answer.js
@@ -2,15 +2,10 @@ function AnswerBlock(runtime, element) {
     return {
         mode: null,
         init: function(options) {
-            // register the child validator
+            // Clear results and validate block when answer changes
             $(':input', element).on('keyup', options.onChange);
 
             this.mode = options.mode;
-            var checkmark = $('.answer-checkmark', element);
-            var completed = $('.xblock-answer', element).data('completed');
-            if (completed === 'True' && this.mode === 'standard') {
-                checkmark.addClass('checkmark-correct icon-ok fa-check');
-            }
 
             // In the LMS, the HTML of multiple units can be loaded at once,
             // and the user can flip among them. If that happens, the answer in
@@ -26,15 +21,15 @@ function AnswerBlock(runtime, element) {
             $('textarea', element).prop('disabled', true);
         },
 
-        handleSubmit: function(result) {
+        handleSubmit: function(result, options) {
 
             var checkmark = $('.answer-checkmark', element);
 
             this.clearResult();
 
-            if (this.mode === 'assessment') {
-                // Display of checkmark would be redundant.
-                return
+            if (options.hide_results || this.mode === 'assessment') {
+                // In assessment mode, display of checkmark would be redundant.
+                return;
             }
             if (result.status) {
                 if (result.status === "correct") {
@@ -66,7 +61,7 @@ function AnswerBlock(runtime, element) {
             var answer_length = input_value.length;
             var data = input.data();
 
-            // an answer cannot be empty event if min_characters is 0
+            // An answer cannot be empty even if min_characters is 0
             if (_.isNumber(data.min_characters)) {
                 var min_characters = _.max([data.min_characters, 1]);
                 if (answer_length < min_characters) {

--- a/problem_builder/public/js/mentoring.js
+++ b/problem_builder/public/js/mentoring.js
@@ -70,10 +70,6 @@ function MentoringBlock(runtime, element) {
     function setContent(dom, content) {
         dom.html('');
         dom.append(content);
-        var template = $('#light-child-template', dom).html();
-        if (template) {
-            dom.append(template);
-        }
     }
 
     function renderAttempts() {

--- a/problem_builder/public/js/mentoring_standard_view.js
+++ b/problem_builder/public/js/mentoring_standard_view.js
@@ -7,6 +7,8 @@ function MentoringStandardView(runtime, element, mentoring) {
     function handleSubmitResults(response, disable_submit) {
         messagesDOM.empty().hide();
 
+        var hide_results = response.message === undefined;
+
         var all_have_results = response.results.length > 0;
         $.each(response.results || [], function(index, result_spec) {
             var input = result_spec[0];
@@ -14,7 +16,8 @@ function MentoringStandardView(runtime, element, mentoring) {
             var child = mentoring.getChildByName(input);
             var options = {
                 max_attempts: response.max_attempts,
-                num_attempts: response.num_attempts
+                num_attempts: response.num_attempts,
+                hide_results: hide_results,
             };
             callIfExists(child, 'handleSubmit', result, options);
             all_have_results = all_have_results && !$.isEmptyObject(result);
@@ -24,11 +27,12 @@ function MentoringStandardView(runtime, element, mentoring) {
         $('.attempts', element).data('num_attempts', response.num_attempts);
         mentoring.renderAttempts();
 
-        // Messages should only be displayed upon hitting 'submit', not on page reload
-        mentoring.setContent(messagesDOM, response.message);
-        if (messagesDOM.html().trim()) {
-            messagesDOM.prepend('<div class="title1">' + mentoring.data.feedback_label + '</div>');
-            messagesDOM.show();
+        if (!hide_results) {
+            mentoring.setContent(messagesDOM, response.message);
+            if (messagesDOM.html().trim()) {
+                messagesDOM.prepend('<div class="title1">' + mentoring.data.feedback_label + '</div>');
+                messagesDOM.show();
+            }
         }
 
         // Disable the submit button if we have just submitted new answers,

--- a/problem_builder/public/js/mentoring_with_steps.js
+++ b/problem_builder/public/js/mentoring_with_steps.js
@@ -312,10 +312,6 @@ function MentoringWithStepsBlock(runtime, element) {
     function setContent(dom, content) {
         dom.html('');
         dom.append(content);
-        var template = $('#light-child-template', dom).html();
-        if (template) {
-            dom.append(template);
-        }
     }
 
     function publishEvent(data) {

--- a/problem_builder/tests/integration/test_mentoring.py
+++ b/problem_builder/tests/integration/test_mentoring.py
@@ -290,38 +290,35 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
         self.assertFalse(messages.is_displayed())
         self.assertFalse(submit.is_enabled())
 
-    @ddt.data(
-        (
-            {
-                'pb_mcq_hide_previous_answer': False,
-                'pb_hide_feedback_if_attempts_remain': False
-            },
-            "_standard_checks"
-        ),
-        (
-            {
-                'pb_mcq_hide_previous_answer': False,
-                'pb_hide_feedback_if_attempts_remain': True
-            },
-            "_hide_feedback_checks"
-        ),
-        (
-            {
-                'pb_mcq_hide_previous_answer': True,
-                'pb_hide_feedback_if_attempts_remain': False
-            },
-            "_mcq_hide_previous_answer_checks"
-        ),
-        (
-            {
-                'pb_mcq_hide_previous_answer': True,
-                'pb_hide_feedback_if_attempts_remain': True
-            },
-            "_mcq_hide_previous_answer_hide_feedback_checks"
-        ),
-    )
-    @ddt.unpack
-    def test_persistence(self, options, after_reload_checks):
+    def test_persists_feedback_on_page_reload(self):
+        options = {
+            'pb_mcq_hide_previous_answer': False,
+            'pb_hide_feedback_if_attempts_remain': False
+        }
+        self._test_persistence(options, "_standard_checks")
+
+    def test_does_not_persist_feedback_on_page_reload_if_disabled(self):
+        options = {
+            'pb_mcq_hide_previous_answer': False,
+            'pb_hide_feedback_if_attempts_remain': True
+        }
+        self._test_persistence(options, "_hide_feedback_checks")
+
+    def test_does_not_persist_mcq_on_page_reload_if_disabled(self):
+        options = {
+            'pb_mcq_hide_previous_answer': True,
+            'pb_hide_feedback_if_attempts_remain': False
+        }
+        self._test_persistence(options, "_mcq_hide_previous_answer_checks")
+
+    def test_does_not_persist_mcq_and_feedback_on_page_reload_if_disabled(self):
+        options = {
+            'pb_mcq_hide_previous_answer': True,
+            'pb_hide_feedback_if_attempts_remain': True
+        }
+        self._test_persistence(options, "_mcq_hide_previous_answer_hide_feedback_checks")
+
+    def _test_persistence(self, options, after_reload_checks):
         with mock.patch("problem_builder.mentoring.MentoringBlock.get_options") as patched_options:
             patched_options.return_value = options
             mentoring = self.load_scenario("feedback_persistence.xml")

--- a/problem_builder/tests/integration/test_mentoring.py
+++ b/problem_builder/tests/integration/test_mentoring.py
@@ -83,8 +83,14 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
     def _get_choice(self, questionnaire, choice_index):
         return questionnaire.find_elements_by_css_selector(".choices-list .choice")[choice_index]
 
+    def _get_answer_checkmark(self, answer):
+        return answer.find_element_by_xpath("parent::*").find_element_by_css_selector(".answer-checkmark")
+
     def _get_messages_element(self, mentoring):
         return mentoring.find_element_by_css_selector('.messages')
+
+    def _get_submit(self, mentoring):
+        return mentoring.find_element_by_css_selector('.submit input.input-main')
 
     def _get_controls(self, mentoring):
         answer = self._get_xblock(mentoring, "feedback_answer_1").find_element_by_css_selector('.answer')
@@ -94,16 +100,38 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
 
         return answer, mcq, mrq, rating
 
+    def _assert_answer(self, answer, results_shown=True):
+        self.assertEqual(answer.get_attribute('value'), 'This is the answer')
+        answer_checkmark = self._get_answer_checkmark(answer)
+        self._assert_checkmark(answer_checkmark, shown=results_shown, checkmark_class='checkmark-correct')
+
     def _assert_checkmark(self, checkmark, shown=True, checkmark_class=None):
-        choice_result_classes = checkmark.get_attribute('class').split()
+        result_classes = checkmark.get_attribute('class').split()
         if shown:
             self.assertTrue(checkmark.is_displayed())
-            self.assertIn(checkmark_class, choice_result_classes)
+            self.assertIn(checkmark_class, result_classes)
         else:
             self.assertFalse(checkmark.is_displayed())
 
-    def _assert_feedback_showed(self, questionnaire, choice_index, expected_text,
-                                click_choice_result=False, success=True):
+    def _assert_mcq(self, mcq, previous_answer_shown=True):
+        if previous_answer_shown:
+            self._assert_feedback_shown(mcq, 0, "Great!", click_choice_result=True)
+        else:
+            for i in range(3):
+                self._assert_feedback_hidden(mcq, i)
+                self._assert_not_checked(mcq, i)
+
+    def _assert_rating(self, rating, previous_answer_shown=True):
+        if previous_answer_shown:
+            self._assert_feedback_shown(rating, 3, "I love good grades.", click_choice_result=True)
+        else:
+            for i in range(5):
+                self._assert_feedback_hidden(rating, i)
+                self._assert_not_checked(rating, i)
+
+    def _assert_feedback_shown(
+            self, questionnaire, choice_index, expected_text, click_choice_result=False, success=True
+    ):
         """
         Asserts that feedback for given element contains particular text
         If `click_choice_result` is True - clicks on `choice-result` icon before checking feedback visibility:
@@ -116,7 +144,7 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
 
         feedback_popup = choice.find_element_by_css_selector(".choice-tips")
         checkmark_class = 'checkmark-correct' if success else 'checkmark-incorrect'
-        self._assert_checkmark(choice_result, shown=True, checkmark_class=checkmark_class)
+        self._assert_checkmark(choice_result, checkmark_class=checkmark_class)
         self.assertTrue(feedback_popup.is_displayed())
         self.assertEqual(feedback_popup.text, expected_text)
 
@@ -124,25 +152,51 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
         choice = self._get_choice(questionnaire, choice_index)
         choice_result = choice.find_element_by_css_selector('.choice-result')
         feedback_popup = choice.find_element_by_css_selector(".choice-tips")
-        choice_result_classes = choice_result.get_attribute('class').split()
+        result_classes = choice_result.get_attribute('class').split()
 
         self.assertTrue(choice_result.is_displayed())
         self.assertFalse(feedback_popup.is_displayed())
-        self.assertNotIn('checkmark-correct', choice_result_classes)
-        self.assertNotIn('checkmark-incorrect', choice_result_classes)
+        self.assertNotIn('checkmark-correct', result_classes)
+        self.assertNotIn('checkmark-incorrect', result_classes)
 
     def _assert_not_checked(self, questionnaire, choice_index):
         choice = self._get_choice(questionnaire, choice_index)
         choice_input = choice.find_element_by_css_selector('input')
         self.assertFalse(choice_input.is_selected())
 
+    def _assert_mrq(self, mrq):
+        self._assert_feedback_shown(
+            mrq, 0, "This is something everyone has to like about this MRQ",
+            click_choice_result=True
+        )
+        self._assert_feedback_shown(
+            mrq, 1, "This is something everyone has to like about beauty",
+            click_choice_result=True, success=False
+        )
+        self._assert_feedback_shown(mrq, 2, "This MRQ is indeed very graceful", click_choice_result=True)
+        self._assert_feedback_shown(mrq, 3, "Nah, there aren't any!", click_choice_result=True, success=False)
+
+    def _assert_messages(self, messages, shown=True):
+        if shown:
+            self.assertTrue(messages.is_displayed())
+            self.assertEqual(messages.text, "FEEDBACK\nNot done yet")
+        else:
+            self.assertFalse(messages.is_displayed())
+            self.assertEqual(messages.text, "")
+
     def _standard_filling(self, answer, mcq, mrq, rating):
+        # Long answer
         answer.send_keys('This is the answer')
+        # MCQ
         self.click_choice(mcq, "Yes")
-        # 1st, 3rd and 4th options, first three are correct, i.e. two mistakes: 2nd and 4th
+        # MRQ: Select 1st, 3rd and 4th options
+        # First three options are required, so we're making two mistakes:
+        # - 2nd option should have been selected
+        # - 4th option should *not* have been selected
         self.click_choice(mrq, "Its elegance")
         self.click_choice(mrq, "Its gracefulness")
         self.click_choice(mrq, "Its bugs")
+        # Rating
         self.click_choice(rating, "4")
 
     # mcq and rating can't be reset easily, but it's not required; listing them here to keep method signature similar
@@ -153,47 +207,56 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
                 checkbox.click()
 
     def _standard_checks(self, answer, mcq, mrq, rating, messages):
-        self.assertEqual(answer.get_attribute('value'), 'This is the answer')
-        self._assert_feedback_showed(mcq, 0, "Great!", click_choice_result=True)
-        self._assert_feedback_showed(
-            mrq, 0, "This is something everyone has to like about this MRQ",
-            click_choice_result=True
-        )
-        self._assert_feedback_showed(
-            mrq, 1, "This is something everyone has to like about beauty",
-            click_choice_result=True, success=False
-        )
-        self._assert_feedback_showed(mrq, 2, "This MRQ is indeed very graceful", click_choice_result=True)
-        self._assert_feedback_showed(mrq, 3, "Nah, there aren't any!", click_choice_result=True, success=False)
-        self._assert_feedback_showed(rating, 3, "I love good grades.", click_choice_result=True)
-        self.assertTrue(messages.is_displayed())
-        self.assertEqual(messages.text, "FEEDBACK\nNot done yet")
+        self.wait_until_visible(messages)
 
-    def _feedback_customized_checks(self, answer, mcq, mrq, rating, messages):
-        # Long answer: Previous answer and feedback visible
-        self.assertEqual(answer.get_attribute('value'), 'This is the answer')
-        # MCQ: Previous answer and feedback hidden
-        for i in range(3):
-            self._assert_feedback_hidden(mcq, i)
-            self._assert_not_checked(mcq, i)
+        # Long answer: Previous answer and results visible
+        self._assert_answer(answer)
+        # MCQ: Previous answer and results visible
+        self._assert_mcq(mcq)
         # MRQ: Previous answer and feedback visible
-        self._assert_feedback_showed(
-            mrq, 0, "This is something everyone has to like about this MRQ",
-            click_choice_result=True
-        )
-        self._assert_feedback_showed(
-            mrq, 1, "This is something everyone has to like about beauty",
-            click_choice_result=True, success=False
-        )
-        self._assert_feedback_showed(mrq, 2, "This MRQ is indeed very graceful", click_choice_result=True)
-        self._assert_feedback_showed(mrq, 3, "Nah, there aren't any!", click_choice_result=True, success=False)
+        self._assert_mrq(mrq)
+        # Rating: Previous answer and results visible
+        self._assert_rating(rating)
+        # Messages visible
+        self._assert_messages(messages)
+
+    def _mcq_hide_previous_answer_checks(self, answer, mcq, mrq, rating, messages):
+        self.wait_until_visible(messages)
+
+        # Long answer: Previous answer and results visible
+        self._assert_answer(answer)
+        # MCQ: Previous answer and results hidden
+        self._assert_mcq(mcq, previous_answer_shown=False)
+        # MRQ: Previous answer and results visible
+        self._assert_mrq(mrq)
+        # Rating: Previous answer and results hidden
+        self._assert_rating(rating, previous_answer_shown=False)
+        # Messages visible
+        self._assert_messages(messages)
+
+    def _hide_feedback_checks(self, answer, mcq, mrq, rating, messages):
+        # Long answer: Previous answer visible and results hidden
+        self._assert_answer(answer, results_shown=False)
+        # MCQ: Previous answer and results visible
+        self._assert_mcq(mcq)
+        # MRQ: Previous answer and results visible
+        self._assert_mrq(mrq)
+        # Rating: Previous answer and results visible
+        self._assert_rating(rating)
+        # Messages hidden
+        self._assert_messages(messages, shown=False)
+
+    def _mcq_hide_previous_answer_hide_feedback_checks(self, answer, mcq, mrq, rating, messages):
+        # Long answer: Previous answer visible and results hidden
+        self._assert_answer(answer, results_shown=False)
+        # MCQ: Previous answer and results hidden
+        self._assert_mcq(mcq, previous_answer_shown=False)
+        # MRQ: Previous answer and results visible
+        self._assert_mrq(mrq)
         # Rating: Previous answer and feedback hidden
-        for i in range(5):
-            self._assert_feedback_hidden(rating, i)
-            self._assert_not_checked(rating, i)
-        # Messages
-        self.assertTrue(messages.is_displayed())
-        self.assertEqual(messages.text, "FEEDBACK\nNot done yet")
+        self._assert_rating(rating, previous_answer_shown=False)
+        # Messages hidden
+        self._assert_messages(messages, shown=False)
 
     def reload_student_view(self):
         # Load another page (the home page), then go back to the page we want. This is the only reliable way to reload.
@@ -203,19 +266,20 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
         def did_load_homepage(driver):
             title = driver.find_element_by_css_selector('h1.title')
             return title and title.text == "XBlock scenarios"
+
         wait.until(did_load_homepage, u"Workbench home page should have loaded")
         mentoring = self.go_to_view("student_view")
-        self.wait_until_visible(self._get_xblock(mentoring, "feedback_mcq_2"))
+        submit = self._get_submit(mentoring)
+        self.wait_until_visible(submit)
         return mentoring
 
-    def test_feedbacks_and_messages_is_not_shown_on_first_load(self):
+    def test_feedback_and_messages_not_shown_on_first_load(self):
         mentoring = self.load_scenario("feedback_persistence.xml")
         answer, mcq, mrq, rating = self._get_controls(mentoring)
         messages = self._get_messages_element(mentoring)
-        submit = mentoring.find_element_by_css_selector('.submit input.input-main')
+        submit = self._get_submit(mentoring)
 
-        answer_checkmark = answer.find_element_by_xpath("parent::*").find_element_by_css_selector(".answer-checkmark")
-
+        answer_checkmark = self._get_answer_checkmark(answer)
         self._assert_checkmark(answer_checkmark, shown=False)
         for i in range(3):
             self._assert_feedback_hidden(mcq, i)
@@ -226,32 +290,40 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
         self.assertFalse(messages.is_displayed())
         self.assertFalse(submit.is_enabled())
 
-    def test_persists_feedback_on_page_reload(self):
-        mentoring = self.load_scenario("feedback_persistence.xml")
-        answer, mcq, mrq, rating = self._get_controls(mentoring)
-        messages = self._get_messages_element(mentoring)
-
-        self._standard_filling(answer, mcq, mrq, rating)
-        self.click_submit(mentoring)
-        self._standard_checks(answer, mcq, mrq, rating, messages)
-
-        # now, reload the page and do the same checks again
-        mentoring = self.reload_student_view()
-        answer, mcq, mrq, rating = self._get_controls(mentoring)
-        messages = self._get_messages_element(mentoring)
-        submit = mentoring.find_element_by_css_selector('.submit input.input-main')
-
-        self._standard_checks(answer, mcq, mrq, rating, messages)
-        # after reloading submit is disabled...
-        self.assertFalse(submit.is_enabled())
-
-        # ...until some changes are done
-        self.click_choice(mrq, "Its elegance")
-        self.assertTrue(submit.is_enabled())
-
-    def test_does_not_persist_mcq_feedback_on_page_reload_if_disabled(self):
+    @ddt.data(
+        (
+            {
+                'pb_mcq_hide_previous_answer': False,
+                'pb_hide_feedback_if_attempts_remain': False
+            },
+            "_standard_checks"
+        ),
+        (
+            {
+                'pb_mcq_hide_previous_answer': False,
+                'pb_hide_feedback_if_attempts_remain': True
+            },
+            "_hide_feedback_checks"
+        ),
+        (
+            {
+                'pb_mcq_hide_previous_answer': True,
+                'pb_hide_feedback_if_attempts_remain': False
+            },
+            "_mcq_hide_previous_answer_checks"
+        ),
+        (
+            {
+                'pb_mcq_hide_previous_answer': True,
+                'pb_hide_feedback_if_attempts_remain': True
+            },
+            "_mcq_hide_previous_answer_hide_feedback_checks"
+        ),
+    )
+    @ddt.unpack
+    def test_persistence(self, options, after_reload_checks):
         with mock.patch("problem_builder.mentoring.MentoringBlock.get_options") as patched_options:
-            patched_options.return_value = {'pb_mcq_hide_previous_answer': True}
+            patched_options.return_value = options
             mentoring = self.load_scenario("feedback_persistence.xml")
             answer, mcq, mrq, rating = self._get_controls(mentoring)
             messages = self._get_messages_element(mentoring)
@@ -260,17 +332,19 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
             self.click_submit(mentoring)
             self._standard_checks(answer, mcq, mrq, rating, messages)
 
-            # now, reload the page and see if previous answers and results for MCQs are hidden
+            # Now reload the page...
             mentoring = self.reload_student_view()
             answer, mcq, mrq, rating = self._get_controls(mentoring)
             messages = self._get_messages_element(mentoring)
-            submit = mentoring.find_element_by_css_selector('.submit input.input-main')
+            submit = self._get_submit(mentoring)
 
-            self._feedback_customized_checks(answer, mcq, mrq, rating, messages)
-            # after reloading submit is disabled...
+            # ... and see if previous answers, results, feedback are shown/hidden correctly
+            getattr(self, after_reload_checks)(answer, mcq, mrq, rating, messages)
+
+            # After reloading, submit is disabled...
             self.assertFalse(submit.is_enabled())
 
-            # ... until student answers MCQs again
+            # ... until student makes changes
             self.click_choice(mcq, "Maybe not")
             self.click_choice(rating, "2")
             self.assertTrue(submit.is_enabled())
@@ -291,18 +365,18 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
 
         # precondition - verifying 100% score achieved
         self.assertEqual(answer.get_attribute('value'), 'This is the answer')
-        self._assert_feedback_showed(mcq, 0, "Great!", click_choice_result=True)
-        self._assert_feedback_showed(
+        self._assert_feedback_shown(mcq, 0, "Great!", click_choice_result=True)
+        self._assert_feedback_shown(
             mrq, 0, "This is something everyone has to like about this MRQ",
             click_choice_result=True
         )
-        self._assert_feedback_showed(
+        self._assert_feedback_shown(
             mrq, 1, "This is something everyone has to like about beauty",
             click_choice_result=True
         )
-        self._assert_feedback_showed(mrq, 2, "This MRQ is indeed very graceful", click_choice_result=True)
-        self._assert_feedback_showed(mrq, 3, "Nah, there aren't any!", click_choice_result=True)
-        self._assert_feedback_showed(rating, 3, "I love good grades.", click_choice_result=True)
+        self._assert_feedback_shown(mrq, 2, "This MRQ is indeed very graceful", click_choice_result=True)
+        self._assert_feedback_shown(mrq, 3, "Nah, there aren't any!", click_choice_result=True)
+        self._assert_feedback_shown(rating, 3, "I love good grades.", click_choice_result=True)
         self.assertTrue(messages.is_displayed())
         self.assertEqual(messages.text, "FEEDBACK\nAll Good")
 
@@ -331,19 +405,20 @@ class ProblemBuilderQuestionnaireBlockTest(ProblemBuilderBaseTest):
         self.click_submit(mentoring)
 
         def assert_state(answer, mcq, mrq, rating, messages):
+            self.wait_until_visible(messages)
             self.assertEqual(answer.get_attribute('value'), 'This is the answer')
-            self._assert_feedback_showed(mcq, 0, "Great!", click_choice_result=True)
-            self._assert_feedback_showed(
+            self._assert_feedback_shown(mcq, 0, "Great!", click_choice_result=True)
+            self._assert_feedback_shown(
                 mrq, 0, "This is something everyone has to like about this MRQ",
                 click_choice_result=True
             )
-            self._assert_feedback_showed(
+            self._assert_feedback_shown(
                 mrq, 1, "This is something everyone has to like about beauty",
                 click_choice_result=True, success=False
             )
-            self._assert_feedback_showed(mrq, 2, "This MRQ is indeed very graceful", click_choice_result=True)
-            self._assert_feedback_showed(mrq, 3, "Nah, there aren't any!", click_choice_result=True)
-            self._assert_feedback_showed(rating, 3, "I love good grades.", click_choice_result=True)
+            self._assert_feedback_shown(mrq, 2, "This MRQ is indeed very graceful", click_choice_result=True)
+            self._assert_feedback_shown(mrq, 3, "Nah, there aren't any!", click_choice_result=True)
+            self._assert_feedback_shown(rating, 3, "I love good grades.", click_choice_result=True)
             self.assertTrue(messages.is_displayed())
             self.assertEqual(messages.text, "FEEDBACK\nNot done yet")
 

--- a/problem_builder/tests/integration/xml_templates/feedback_persistence.xml
+++ b/problem_builder/tests/integration/xml_templates/feedback_persistence.xml
@@ -12,7 +12,7 @@
             <pb-tip values='["understand"]'><div id="test-custom-html">Really?</div></pb-tip>
         </pb-mcq>
 
-        <pb-mrq name="feedback_mrq_3" question="What do you like in this MRQ?" required_choices='["elegance","gracefulness","beauty"]'>
+        <pb-mrq name="feedback_mrq_3" question="What do you like in this MRQ?" required_choices='["elegance","beauty","gracefulness"]'>
             <pb-choice value="elegance">Its elegance</pb-choice>
             <pb-choice value="beauty">Its beauty</pb-choice>
             <pb-choice value="gracefulness">Its gracefulness</pb-choice>

--- a/problem_builder/tests/unit/test_problem_builder.py
+++ b/problem_builder/tests/unit/test_problem_builder.py
@@ -221,7 +221,7 @@ class TestMentoringBlockOptions(unittest.TestCase):
             patched_get_options.return_value = {}
             option = self.block.get_option(random_key)
             patched_get_options.assert_called_once_with()
-            self.assertEqual(option, False)
+            self.assertEqual(option, None)
 
     def test_student_view_calls_get_option(self):
         self.block.get_xblock_settings = Mock(return_value={})


### PR DESCRIPTION
This PR introduces an instance-wide option to hide global feedback and results (correct/incorrect) icons for Long Answer blocks in Problem Builder. When this option is enabled (and there are some attempts left), students will still receive global and per-question feedback after providing answers and submitting the containing block, but that feedback will not be visible when they return to the block.

cf. [MCKIN-3858](https://edx-wiki.atlassian.net/browse/MCKIN-3858)

**Screenshots: LMS**

Default settings:

![lms-pb-option-disabled](https://cloud.githubusercontent.com/assets/961441/13508344/e552e452-e186-11e5-8714-c86d242d61a7.png)

Feedback hidden:

![lms-pb-option-enabled](https://cloud.githubusercontent.com/assets/961441/13508351/eb85f418-e186-11e5-918c-d45e89d0dfbd.png)

---

**Screenshots: Apros**

Default settings:

![apros-pb-option-disabled](https://cloud.githubusercontent.com/assets/961441/13508357/f17083f2-e186-11e5-9d3d-82660744ab86.png)

Feedback hidden:

![apros-pb-option-enabled](https://cloud.githubusercontent.com/assets/961441/13508363/f667b434-e186-11e5-86a0-c048daf377c5.png)

**Test instructions**

1. Create a subsection with two units and add a Problem Builder block to each one.

2. Add a long answer, MCQ, Rating, MRQ, and Slider to one of the Problem Builder blocks.

3. Publish the units.

4. In LMS/Apros, provide answers to all questions and click "Submit".

5. Navigate to the other unit, then come back to the first unit. Observe that Problem Builder shows global and per-question feedback for all questions.

6. In `lms.env.json`, enable the new option by modifying the `XBLOCK_SETTINGS` for `mentoring`:

   ```js
        "mentoring": {
            "theme": {
                // ...
            },
            "options": {
                "pb_hide_feedback_if_attempts_remain": true
            }
        },
   ```

7. Restart LMS/Apros and reload the page showing the first unit. Observe that Problem Builder does not show global feedback and results for the Long Answer are hidden.
