### PR TITLE
Restore functionality for showing choice tips on click

### DIFF
--- a/problem_builder/public/js/questionnaire.js
+++ b/problem_builder/public/js/questionnaire.js
@@ -10,7 +10,7 @@ function display_message(message, messageView, checkmark){
             checkmark.on('click', function(ev) {
                 ev.stopPropagation();
                 messageView.showMessage(msg);
-            })
+            });
         }
     }
 }
@@ -140,7 +140,11 @@ function MCQBlock(runtime, element) {
                     choiceDOM.addClass('incorrect');
                     choiceResultDOM.addClass('checkmark-incorrect icon-exclamation fa-exclamation');
                 }
-
+                choiceResultDOM.off('click').on('click', function() {
+                    if (choiceTipsDOM.html() !== '') {
+                        messageView.showMessage(choiceTipsDOM);
+                    }
+                });
                 if (result.tips) {
                     mentoring.setContent(choiceTipsDOM, result.tips);
                     messageView.showMessage(choiceTipsDOM);


### PR DESCRIPTION
cf. [MCKIN-3884](https://edx-wiki.atlassian.net/browse/MCKIN-3884)

**Test instructions**

1. Add Problem Builder block to a unit.

2. Add MCQ block to Problem Builder block.

3. Add a couple of Choice blocks to MCQ block.

4. For each choice, add a Tip block with a unique message.

5. Publish.

6. In LMS/Apros, answer question, click "Submit". Once tip for selected choice is visible, click somewhere else to make tip disappear.

7. Click result icon next to selected choice. Observe that tip becomes visible again.
