### PR TITLE
Fix dashboard report image download (edx-release hotfix)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
     - "pip install -r requirements.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt"
-    - "pip uninstall -y xblock-problem-builder && python setup.py sdist && pip install dist/xblock-problem-builder-2.0.2.tar.gz"
+    - "pip uninstall -y xblock-problem-builder && python setup.py sdist && pip install dist/xblock-problem-builder-2.0.3.tar.gz"
     - "pip install -r test_requirements.txt"
     - "mkdir var"
 script:

--- a/problem_builder/public/js/dashboard.js
+++ b/problem_builder/public/js/dashboard.js
@@ -8,6 +8,18 @@ function PBDashboardBlock(runtime, element, initData) {
     var generateDataUriFromImageURL = function(imgURL) {
         // Given the URL to an image, IF the image has already been cached by the browser,
         // returns a data: URI with the contents of the image (image will be converted to PNG)
+
+        // Expand relative urls and urls without an explicit protocol into absolute urls
+        var a = document.createElement('a');
+        a.href = imgURL;
+        imgURL = a.href;
+
+        // If the image is from another domain, just return its URL. We can't
+        // create a data URL from cross-domain images:
+        // https://html.spec.whatwg.org/multipage/scripting.html#dom-canvas-todataurl
+        if (a.origin !== window.location.origin)
+            return imgURL;
+
         var img = new Image();
         img.src = imgURL;
         if (!img.complete)

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='2.0.2',
+    version='2.0.3',
     description='XBlock - Problem Builder',
     packages=['problem_builder', 'problem_builder.v1'],
     install_requires=[


### PR DESCRIPTION
The dashboard report image download can currently fail in 2 different ways:

- If the image is from a different domain and it has been cached by the browser, it won't be converted into a data URL due to cross-domain security issues. A javascript `SecurityError` is thrown, and nothing happens.
- If the image url starts with `//` (no explicit protocol) or the url is relative (e.g. `/static/...`), *and* it hasn't yet been cached by the browser, it will fail to show up in the downloaded report.

This pull request fixes both issues, by:

- Not trying to create a data URL for cross-domain requests
- Expanding relative urls and urls without an explicit protocol