### PR TITLE
StepBuilder: Fix inconsistent feedback for MCQs

### DIFF
--- a/problem_builder/public/js/questionnaire.js
+++ b/problem_builder/public/js/questionnaire.js
@@ -195,7 +195,7 @@ function MRQBlock(runtime, element) {
 
         handleReview: function(result) {
             $.each(result.submissions, function (index, value) {
-                $('input[type="checkbox"][value="' + value + '"]').prop('checked', true)
+                $('input[type="checkbox"][value="' + value + '"]').prop('checked', true);
             });
             $('input', element).prop('disabled', true);
         },

--- a/problem_builder/public/js/step.js
+++ b/problem_builder/public/js/step.js
@@ -89,8 +89,15 @@ function MentoringStepBlock(runtime, element) {
                 var child = children[i];
                 if (child && child.name !== undefined) { // Check if we are dealing with a question
                     var result = results[child.name];
-                    callIfExists(child, 'handleSubmit', result, options);
+                    // Call handleReview first to ensure that choice-level feedback for MCQs is displayed:
+                    // Before displaying feedback for a given choice, handleSubmit checks if it is selected.
+                    // (If it isn't, we don't want to display feedback for it.)
+                    // handleReview is responsible for setting the "checked" property to true
+                    // for each choice that the student selected as part of their most recent submission.
+                    // If it is called after handleSubmit, the check mentioned above will fail,
+                    // and no feedback will be displayed.
                     callIfExists(child, 'handleReview', result);
+                    callIfExists(child, 'handleSubmit', result, options);
                 }
             }
         },
@@ -100,7 +107,7 @@ function MentoringStepBlock(runtime, element) {
         },
 
         hasQuestion: function() {
-            return $('.sb-step', element).data('has-question')
+            return $('.sb-step', element).data('has-question');
         },
 
         updateChildren: function() {

--- a/problem_builder/tests/integration/xml_templates/step_builder_mcq_feedback.xml
+++ b/problem_builder/tests/integration/xml_templates/step_builder_mcq_feedback.xml
@@ -1,0 +1,20 @@
+<step-builder url_name="step-builder" display_name="Step Builder"
+              max_attempts="{{max_attempts}}" extended_feedback="{{extended_feedback}}">
+
+  <sb-step display_name="First step">
+    <pb-mcq name="mcq_1_1" question="Do you like this MCQ?" correct_choices='["yes"]'>
+        <pb-choice value="yes">Yes</pb-choice>
+        <pb-choice value="maybenot">Maybe not</pb-choice>
+        <pb-choice value="understand">I don't understand</pb-choice>
+
+        <pb-tip values='["yes"]'>Great!</pb-tip>
+        <pb-tip values='["maybenot"]'>Ah, damn.</pb-tip>
+        <pb-tip values='["understand"]'><div id="test-custom-html">Really?</div></pb-tip>
+    </pb-mcq>
+  </sb-step>
+
+  <sb-review-step>
+    <sb-review-score/>
+  </sb-review-step>
+
+</step-builder>


### PR DESCRIPTION
cf. [MCKIN-3907](https://edx-wiki.atlassian.net/browse/MCKIN-3907)

**Test instructions**

1. Create new unit and add StepBuilder block to it.
2. Set "Max. attempts allowed" to `1` and "Extended feedback" to `True` for StepBuilder block.
3. Add MentoringStep block to StepBuilder.
4. Add MCQ block to MentoringStep.
5. Add two Choice blocks to MCQ.
6. Add two Tip blocks to MCQ, one for each Choice (with custom "Content").
7. Add ReviewStep block to StepBuilder.
8. Add ScoreSummary block to ReviewStep.
8. Publish.
9. Complete StepBuilder block in LMS/Apros and "Review grade".
10. Jump back to MCQ by clicking corresponding link. Observe that feedback and result (checkmark) for choice you selected is shown right away.
11. Reload page.
12. Repeat step 10. Observe that feedback and result (checkmark) for choice you selected is shown right away.
13. Click "Review final grade" button to go back to review step, *without* reloading page.
14. Repeat step 10. Observe that feedback and result (checkmark) for choice you selected is shown right away.