### PR TITLE
OC-1441 Detach step elements from DOM or stop playback of closed steps

### DIFF
--- a/problem_builder/public/js/mentoring_with_steps.js
+++ b/problem_builder/public/js/mentoring_with_steps.js
@@ -97,7 +97,7 @@ function MentoringWithStepsBlock(runtime, element) {
     }
 
     /**
-     * Displays active step
+     * Displays the active step
      */
     function showActiveStep() {
         var step = getWrapperForActiveStep();

--- a/problem_builder/public/js/mentoring_with_steps.js
+++ b/problem_builder/public/js/mentoring_with_steps.js
@@ -43,8 +43,8 @@ function MentoringWithStepsBlock(runtime, element) {
         return getStepByIndex(activeStepIndex);
     }
 
-    function getActiveStepBlock() {
-        return getActiveStep()['xblock'];
+    function getActiveBlock() {
+        return getActiveStep().xblock;
     }
 
     function getStepByIndex(idx){
@@ -64,7 +64,6 @@ function MentoringWithStepsBlock(runtime, element) {
     }
 
     function showStep(step) {
-        // step.$element.insertAfter(step.$anchor);
         step.$element.show();
     }
 
@@ -104,7 +103,7 @@ function MentoringWithStepsBlock(runtime, element) {
         } else {
             checkmark.addClass('checkmark-incorrect icon-exclamation fa-exclamation');
         }
-        var step = getActiveStepBlock();
+        var step = getActiveBlock();
         if (typeof step.showFeedback == 'function') {
             step.showFeedback(response);
         }
@@ -133,7 +132,7 @@ function MentoringWithStepsBlock(runtime, element) {
     function submit() {
         submitDOM.attr('disabled', 'disabled'); // Disable the button until the results load.
         var submitUrl = runtime.handlerUrl(element, 'submit');
-        var activeStep = getActiveStepBlock();
+        var activeStep = getActiveBlock();
         var hasQuestion = activeStep.hasQuestion();
         var data = activeStep.getSubmitData();
         data["active_step"] = activeStepIndex;
@@ -157,14 +156,14 @@ function MentoringWithStepsBlock(runtime, element) {
     }
 
     function getResults() {
-        getActiveStepBlock().getResults(handleReviewResults);
+        getActiveBlock().getResults(handleReviewResults);
     }
 
     function handleReviewResults(response) {
         // Show step-level feedback
         showFeedback(response);
         // Forward to active step to show answer level feedback
-        var step = getActiveStepBlock();
+        var step = getActiveBlock();
         var results = response.results;
         var options = {
             checkmark: checkmark
@@ -188,7 +187,7 @@ function MentoringWithStepsBlock(runtime, element) {
     }
 
     function updateNextLabel() {
-        var step = getActiveStepBlock();
+        var step = getActiveBlock();
         nextDOM.attr('value', step.getStepLabel());
     }
 
@@ -213,7 +212,7 @@ function MentoringWithStepsBlock(runtime, element) {
             nextDOM.on('click', updateDisplay);
             reviewButtonDOM.on('click', showGrade);
 
-            var step = getActiveStepBlock();
+            var step = getActiveBlock();
             if (step.hasQuestion()) {  // Step includes one or more questions
                 nextDOM.attr('disabled', 'disabled');
                 submitDOM.show();
@@ -294,7 +293,7 @@ function MentoringWithStepsBlock(runtime, element) {
             nextDOM.show();
             nextDOM.removeAttr('disabled');
         }
-        var step = getActiveStepBlock();
+        var step = getActiveBlock();
 
         tryAgainDOM.hide();
         if (step.hasQuestion()) {
@@ -330,7 +329,7 @@ function MentoringWithStepsBlock(runtime, element) {
 
     function validateXBlock() {
         var isValid = true;
-        var step = getActiveStepBlock();
+        var step = getActiveBlock();
         if (step) {
             isValid = step.validate();
         }

--- a/problem_builder/public/js/mentoring_with_steps.js
+++ b/problem_builder/public/js/mentoring_with_steps.js
@@ -27,7 +27,8 @@ function MentoringWithStepsBlock(runtime, element) {
     var hasAReviewStep = reviewStepDOM.length == 1;
     
     /**
-     * Registers step to in this builder, it stores the xblock element, and some additional metadata used to safely
+     * Registers step with this StepBuilder instance: Creates and stores a wrapper that contains the XBlock instance
+     * and associated DOM element, as well as some additional metadata used to safely
      * remove and re-attach xblock to the DOM. See showStep and hideStep to see why we need to do it.
      * @param step xblock instance to register
      */
@@ -36,7 +37,6 @@ function MentoringWithStepsBlock(runtime, element) {
         var $anchor = $('<span class="xblock-sb-anchor"/>');
         $anchor.insertBefore($element);
         var step_wrapper = {
-            idx: step.length,
             $element: $element,
             xblock: step,
             $anchor: $anchor
@@ -45,16 +45,16 @@ function MentoringWithStepsBlock(runtime, element) {
     }
 
     /**
-     * Returns wrapper for active step
-     * @returns {*}, an object containing xblock, and additional metadata (see registerStep where this object is created
-     * for properties)
+     * Returns wrapper for the active step
+     * @returns {*}, an object containing the XBlock instance and associated DOM element for the active step, as well
+     * as additional metadata (see registerStep where this object is created for properties)
      */
     function getWrapperForActiveStep() {
         return steps[activeStepIndex];
     }
 
     /**
-     * Returns active step)
+     * Returns the active step
      * @returns {*}
      */
     function getActiveStep() {
@@ -62,13 +62,13 @@ function MentoringWithStepsBlock(runtime, element) {
     }
 
     /**
-     * Calls a function for each registered step. Object passed to this function is an step wrapper object
-     * (see registerStep where this object is created a list of properties)
+     * Calls a function for each registered step. The object passed to this function is a step wrapper object
+     * (see registerStep where this object is created for a list of properties)
      *
      * @param func single arg function.
      */
     function forEachStep(func){
-        for (var idx=0; idx<steps.length; idx++) {
+        for (var idx=0; idx < steps.length; idx++) {
             func(steps[idx]);
         }
     }
@@ -87,10 +87,12 @@ function MentoringWithStepsBlock(runtime, element) {
      * @param step_wrapper
      */
     function hideStep(step_wrapper) {
-        // This is a hacky workaround, but it works. It detaches this element from dom, and re-attaches it immediately,
+        // This is a hacky workaround, but it works. It detaches this element from DOM, and re-attaches it immediately,
         // which has the side effect of stopping any video elements (tested with Ooyala and Youtube). 
-        // This solution was chosen as permanently detaching xblocks from DOM is not anticipated by lot of software 
-        // and some code in this repository. 
+        // This solution was chosen as permanently detaching xblocks from DOM is not anticipated by:
+        //  * Selenium tests
+        //  * Some javascript code here
+        //  * Anything else that inspects DOM elements and makes choices         
         step_wrapper.$element.detach();
         step_wrapper.$element.insertAfter(step_wrapper.$anchor);
         step_wrapper.$element.hide();

--- a/problem_builder/public/js/mentoring_with_steps.js
+++ b/problem_builder/public/js/mentoring_with_steps.js
@@ -50,7 +50,7 @@ function MentoringWithStepsBlock(runtime, element) {
      * for properties)
      */
     function getWrapperForActiveStep() {
-        return steps[activeStepIndex](activeStepIndex);
+        return steps[activeStepIndex];
     }
 
     /**

--- a/problem_builder/tests/integration/test_step_builder.py
+++ b/problem_builder/tests/integration/test_step_builder.py
@@ -624,9 +624,6 @@ class StepBuilderTest(MentoringAssessmentBaseTest, MultipleSliderBlocksTestMixin
 
     @data(True, False)
     def test_conditional_messages(self, include_messages):
-        """
-        Test that conditional messages in the review step are visible or not, as appropriate.
-        """
         max_attempts = 3
         extended_feedback = False
         params = {
@@ -1371,7 +1368,7 @@ class StepBuilderTest(MentoringAssessmentBaseTest, MultipleSliderBlocksTestMixin
 
     def provide_freeform_answer(self, step_number, question_number, step_builder, text_input):
         steps = step_builder.find_elements_by_css_selector('div[data-block-type="sb-step"]')
-        current_step = steps[step_number-1]
+        current_step = steps[0]
         freeform_questions = current_step.find_elements_by_css_selector('div[data-block-type="pb-answer"]')
         current_question = freeform_questions[question_number-1]
 

--- a/problem_builder/tests/integration/test_step_builder.py
+++ b/problem_builder/tests/integration/test_step_builder.py
@@ -624,6 +624,9 @@ class StepBuilderTest(MentoringAssessmentBaseTest, MultipleSliderBlocksTestMixin
 
     @data(True, False)
     def test_conditional_messages(self, include_messages):
+        """
+        Test that conditional messages in the review step are visible or not, as appropriate.
+        """
         max_attempts = 3
         extended_feedback = False
         params = {
@@ -1368,7 +1371,7 @@ class StepBuilderTest(MentoringAssessmentBaseTest, MultipleSliderBlocksTestMixin
 
     def provide_freeform_answer(self, step_number, question_number, step_builder, text_input):
         steps = step_builder.find_elements_by_css_selector('div[data-block-type="sb-step"]')
-        current_step = steps[0]
+        current_step = steps[step_number-1]
         freeform_questions = current_step.find_elements_by_css_selector('div[data-block-type="pb-answer"]')
         current_question = freeform_questions[question_number-1]
 


### PR DESCRIPTION
This is initial implementation of OC-1441, this stops playback of videos from previous steps. 

## Course set up

What you need is a course where on a step you have a video, and then you can to the next step (you should still hear the video on that next step --- which is the error). 

1. Create a course with two sections, each containing a single subsection and a single unit. 
2. Each unit contains a step-builder with three steps. First step contains a video and a question, second contains a question, and the last one is the review step. 
3. In one of the subsections use a normal Video XBlock, in second use HTML with OOyala player (OOyala set-up is described in the OC-1441 issue). 

Essentially you should have a course that looks like this: 
```
* Section 1
 * Subsection 1
   * Unit 1
    * Step Builder
     * Step 1
      * Video XBlock with a video
      * Question 
    * Step 2 
     * Question
    * Step 3
     * Review
* Section 2
 * Subsection 2
   * Unit 1
    * Step Builder
     * Step 1
      * HTML Xblock with OOyala video
      * Question 
    * Step 2 
     * Question
    * Step 3
     * Review
```


##  Verification instructions

1. Download the course attached to OC-1441 (for anyone from outside OpenCraft: this course just contains two StepBuilder units containing first step with a video, then step with a quiz and then step with a review; first block contains an Youtube video loaded using a Video XBlock, and second one contains an OOlaya video embedded using HTML Xblock). 
2. Please note that OOyala video needs to be manually started by pasting a snippet to a javascript console --- snippet is attached above the video, and looks like that: `OO.ready(function() { OO.Player.create('xxx', 'yyy_zzz'); });`. After you start the video it should work as it was started "normally" so tests are still valid. 
3. Go to video and block, start the video and wait until it loads, fill in the quiz and go to next step. Note that you still hear video music in the background. 
4. Check the same with the OOyala video subsection. 

## Testing instructions

1. Checkout this branch.
2. Go to video and block, start the video and wait until it loads, fill in the quiz and go to next step. Note that the video is no longer playing in the background. 
3. Fill in rest of the quiz, watch the review step, and go back to the video step. Verify that video is still working properly. 
4. Check the same with the OOyala video subsection. 
