### PR TITLE
Stopping video playback for hidden steps

### DIFF
--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -1027,6 +1027,7 @@ class MentoringWithExplicitStepsBlock(BaseMentoringBlock, StudioContainerWithNes
         }))
         fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/problem-builder.css'))
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/vendor/underscore-min.js'))
+        fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/lms_util.js'))
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/mentoring_with_steps.js'))
 
         fragment.add_resource(loader.load_unicode('templates/html/mentoring_attempts.html'), "text/html")

--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -1027,7 +1027,7 @@ class MentoringWithExplicitStepsBlock(BaseMentoringBlock, StudioContainerWithNes
         }))
         fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/problem-builder.css'))
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/vendor/underscore-min.js'))
-        fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/lms_util.js'))
+        fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/step_util.js'))
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/mentoring_with_steps.js'))
 
         fragment.add_resource(loader.load_unicode('templates/html/mentoring_attempts.html'), "text/html")

--- a/problem_builder/public/js/lms_util.js
+++ b/problem_builder/public/js/lms_util.js
@@ -1,8 +1,8 @@
 (function () {
 
     /**
-     *  Manager for HTML XBlocks. These blocks are hid by detaching and shown
-     *  by re-attaching them to the DOM.This is only generic way to generically
+     *  Manager for HTML XBlocks. These blocks are hidden by detaching and shown
+     *  by re-attaching them to the DOM. This is only way to generically
      *  handle things like video players (they should stop playing when removed from DOM).
      *
      *  @param html an html xblock
@@ -20,31 +20,29 @@
     
     /**
      *
-     * Manager for HTML Video child. Videos are paused when hiding them, and re-sized when showing them.
+     * Manager for HTML Video child. Videos are re-sized when showing them.
      * @param video an video xblock
      *
      */
     function VideoManager(video) {
         this.show = function () {
-            if (typeof video.resizer === 'undefined'){
+            if (typeof video.resizer === 'undefined') {
                 // This one is tricky: but it looks like resizer is undefined only if the video is on the
                 // step that is initially visible (and then no resizing is necessary)
                 return;
             }
             video.resizer.align();
         };
-        this.hide = function () {
-            if (typeof video.videoPlayer === 'undefined'){
-                // If video player is undefined this means that the video isn't loaded yet, so no need to
-                // pause it.
-                return;
-            }
-            video.videoPlayer.pause();
-        };
+        /**
+         * Videos should be paused when user leaves a step containing a video. There is was a proposed implementation
+         * but since it didn't work on every system we decided to drop it (it was out of scope for current task
+         * nevertheless). See OC-1441 for details.
+         */
+        this.hide = function () {};
     }
     
     /**
-     *  Manager for Plot Xblocks. Handles updating a plot before displaying it.
+     * Manager for Plot Xblocks. Handles updating a plot before displaying it.
      * @param plot
      */
     function PlotManager(plot) {
@@ -65,48 +63,48 @@
         var children = runtime.children(xblock_element);
 
         /**
-         * A list of managers for children than need special care when showing or hiding.
+         * A list of managers for children that need special care when showing or hiding.
          *
          * @type {show, hide}[]
          */
         var managedChildren = [];
 
         /***
-         * This is a workaround for issue where jquery.xblock.Runtime doesn't return HTML Xblocks when querying
+         * This is a workaround for issue where jquery.xblock.Runtime doesn't return HTML blocks when querying
          * for children.
          *
          * This can be removed when:
          *
-         * * We allow inclusion of Ooyala blocks inside ProblemBuilder and our clients migrate to Ooyala, in this case
+         * * We allow inclusion of Ooyala blocks inside StepBuilder and our clients migrate to Ooyala, in this case
          *   we may drop special handling of HTML blocks. See discussions in OC-1441.
          * * We include HTML blocks in runtime.children for runtime of jquery.xblock, then just add
          *   `html: HtmlManager` to `Managers`, and remove this block.
          */
-        $("div.xblock.xblock-student_view.xmodule_HtmlModule", xblock_element).each(function (idx, element) {
-            managedChildren.push(new HtmlManager({element:element}));
+        $("div.xblock.xblock-student_view.xmodule_HtmlModule", xblock_element).each(function(idx, element) {
+            managedChildren.push(new HtmlManager({ element: element }));
         });
 
-        for (var idx = 0; idx < children.length; idx++){
+        for (var idx = 0; idx < children.length; idx++) {
             var child = children[idx];
-            // NOTE: While following assertion is true for e.g Video blocks:
-            // child.type == $(child.element).data('block-type') it is invalidated by for all sb-* blocks
+            // NOTE: While the following assertion is true for e.g Video blocks:
+            // child.type == $(child.element).data('block-type') it is invalid for all sb-* blocks
             var type =  $(child.element).data('block-type');
             var constructor = Managers[type];
-            if (typeof constructor === 'undefined'){
+            if (typeof constructor === 'undefined') {
                 // This block does not requires special care, moving on 
-                continue ;
+                continue;
             }
             managedChildren.push(new constructor(child));
         }
         
         this.show = function () {
-            for (var idx = 0; idx<managedChildren.length; idx++){
+            for (var idx = 0; idx < managedChildren.length; idx++) {
                 managedChildren[idx].show();
             }
         }; 
         
         this.hide = function () {
-            for (var idx = 0; idx<managedChildren.length; idx++){
+            for (var idx = 0; idx < managedChildren.length; idx++) {
                 managedChildren[idx].hide();
             }
         };

--- a/problem_builder/public/js/lms_util.js
+++ b/problem_builder/public/js/lms_util.js
@@ -1,0 +1,122 @@
+(function () {
+
+    /**
+     *  Manager for HTML XBlocks. These blocks are hid by detaching and shown
+     *  by re-attaching them to the DOM.This is only generic way to generically
+     *  handle things like video players (they should stop playing when removed from DOM).
+     *
+     *  @param html an html xblock
+     */
+    function HtmlManager(html) {
+        var $element = $(html.element);
+        var $anchor = $("<span>").addClass("sb-video-anchor").insertBefore($element);
+        this.show = function () {
+            $element.insertAfter($anchor);
+        };
+        this.hide = function () {
+            $element.detach()
+        };
+    }
+    
+    /**
+     *
+     * Manager for HTML Video child. Videos are paused when hiding them, and re-sized when showing them.
+     * @param video an video xblock
+     *
+     */
+    function VideoManager(video) {
+        this.show = function () {
+            if (typeof video.resizer === 'undefined'){
+                // This one is tricky: but it looks like resizer is undefined only if the video is on the
+                // step that is initially visible (and then no resizing is necessary)
+                return;
+            }
+            video.resizer.align();
+        };
+        this.hide = function () {
+            if (typeof video.videoPlayer === 'undefined'){
+                // If video player is undefined this means that the video isn't loaded yet, so no need to
+                // pause it.
+                return;
+            }
+            video.videoPlayer.pause();
+        };
+    }
+    
+    /**
+     *  Manager for Plot Xblocks. Handles updating a plot before displaying it.
+     * @param plot
+     */
+    function PlotManager(plot) {
+        this.show = function () {
+            plot.update();
+        };
+        this.hide = function () {};
+    }
+
+
+    function ChildManager(xblock_element, runtime) {
+
+        var Managers = {
+            'video': VideoManager,
+            'sb-plot': PlotManager
+        };
+
+        var children = runtime.children(xblock_element);
+
+        /**
+         * A list of managers for children than need special care when showing or hiding.
+         *
+         * @type {show, hide}[]
+         */
+        var managedChildren = [];
+
+        /***
+         * This is a workaround for issue where jquery.xblock.Runtime doesn't return HTML Xblocks when querying
+         * for children.
+         *
+         * This can be removed when:
+         *
+         * * We allow inclusion of Ooyala blocks inside ProblemBuilder and our clients migrate to Ooyala, in this case
+         *   we may drop special handling of HTML blocks. See discussions in OC-1441.
+         * * We include HTML blocks in runtime.children for runtime of jquery.xblock, then just add
+         *   `html: HtmlManager` to `Managers`, and remove this block.
+         */
+        $("div.xblock.xblock-student_view.xmodule_HtmlModule", xblock_element).each(function (idx, element) {
+            managedChildren.push(new HtmlManager({element:element}));
+        });
+
+        for (var idx = 0; idx < children.length; idx++){
+            var child = children[idx];
+            // NOTE: While following assertion is true for e.g Video blocks:
+            // child.type == $(child.element).data('block-type') it is invalidated by for all sb-* blocks
+            var type =  $(child.element).data('block-type');
+            var constructor = Managers[type];
+            if (typeof constructor === 'undefined'){
+                // This block does not requires special care, moving on 
+                continue ;
+            }
+            managedChildren.push(new constructor(child));
+        }
+        
+        this.show = function () {
+            for (var idx = 0; idx<managedChildren.length; idx++){
+                managedChildren[idx].show();
+            }
+        }; 
+        
+        this.hide = function () {
+            for (var idx = 0; idx<managedChildren.length; idx++){
+                managedChildren[idx].hide();
+            }
+        };
+
+    }
+
+    window.ProblemBuilderUtilLMS = {
+
+        ChildManager: ChildManager
+
+    };
+})();
+

--- a/problem_builder/public/js/mentoring_with_steps.js
+++ b/problem_builder/public/js/mentoring_with_steps.js
@@ -40,7 +40,7 @@ function MentoringWithStepsBlock(runtime, element) {
      *
      * @param func single arg function.
      */
-    function forEachStep(func){
+    function forEachStep(func) {
         for (var idx=0; idx < steps.length; idx++) {
             func(steps[idx]);
         }
@@ -51,15 +51,15 @@ function MentoringWithStepsBlock(runtime, element) {
      */
     function showActiveStep() {
         var step = getActiveStep();
-        step.show();
+        step.showStep();
     }
 
     /**
      * Hides all steps
      */
     function hideAllSteps() {
-        forEachStep(function(step){
-            step.hide();
+        forEachStep(function(step) {
+            step.hideStep();
         });
     }
 
@@ -251,17 +251,19 @@ function MentoringWithStepsBlock(runtime, element) {
         reviewButtonDOM.hide();
         tryAgainDOM.show();
 
-        /**
-         * We detach review step from DOM, this is required to handle HTML
-         * blocks that can be added to the Review step.
-         *
-         * NOTE: This is handled differently than step js. As the html contents
-         * of review step are replaced with fresh contents in submit function.  
-         */
+        // reviewStepDOM is detached in hideReviewStep
         reviewStepDOM.insertBefore(reviewStepAnchor);
         reviewStepDOM.show();
     }
 
+    /**
+     * We detach review step from DOM, this is required to handle HTML
+     * blocks with embedded videos, that can be added to that step.
+     *
+     * NOTE: Review steps are handled differently than "normal" steps:
+     * the HTML contents of a review step are replaced with fresh 
+     * contents in submit function.
+     */
     function hideReviewStep() {
         reviewStepDOM.hide();
         reviewStepDOM.detach();
@@ -311,7 +313,6 @@ function MentoringWithStepsBlock(runtime, element) {
             attemptsDOM.html(attemptsTemplate(data));
         } // Don't show attempts if unlimited attempts available (max_attempts === 0)
     }
-
 
     function onChange() {
         // We do not allow users to modify answers belonging to a step after submitting them:
@@ -413,7 +414,7 @@ function MentoringWithStepsBlock(runtime, element) {
         submitXHR = $.post(handlerUrl, JSON.stringify({})).success(handleTryAgain);
     }
 
-    function notify(name, data){
+    function notify(name, data) {
         // Notification interface does not exist in the workbench.
         if (runtime.notify) {
             runtime.notify(name, data);
@@ -439,7 +440,7 @@ function MentoringWithStepsBlock(runtime, element) {
             var itemFeedbackParentSelector = '.choice';
             var itemFeedbackSelector = ".choice .choice-tips";
 
-            function clickedInside(selector, parent_selector){
+            function clickedInside(selector, parent_selector) {
                 return target.is(selector) || target.parents(parent_selector).length>0;
             }
 

--- a/problem_builder/public/js/step.js
+++ b/problem_builder/public/js/step.js
@@ -4,6 +4,8 @@ function MentoringStepBlock(runtime, element) {
 
     var submitXHR, resultsXHR,
         message = $(element).find('.sb-step-message');
+    
+    var childManager = new ProblemBuilderUtilLMS.ChildManager(element, runtime);
 
     function callIfExists(obj, fn) {
         if (typeof obj !== 'undefined' && typeof obj[fn] == 'function') {
@@ -13,13 +15,6 @@ function MentoringStepBlock(runtime, element) {
         }
     }
 
-    function updateVideo(video) {
-        video.resizer.align();
-    }
-
-    function updatePlot(plot) {
-        plot.update();
-    }
 
     return {
 
@@ -56,7 +51,7 @@ function MentoringStepBlock(runtime, element) {
         },
 
         showFeedback: function(response) {
-            // Called when user has just submitted an answer or is reviewing their answer durign extended feedback.
+            // Called when user has just submitted an answer or is reviewing their answer during extended feedback.
             if (message.length) {
                 message.fadeIn();
                 $(document).click(function() {
@@ -110,20 +105,15 @@ function MentoringStepBlock(runtime, element) {
             return $('.sb-step', element).data('has-question');
         },
 
-        updateChildren: function() {
-            children.forEach(function(child) {
-                var type = $(child.element).data('block-type');
-                switch (type) {
-                case 'video':
-                    updateVideo(child);
-                    break;
-                case 'sb-plot':
-                    updatePlot(child);
-                    break;
-                }
-            });
-        }
+        show: function () {
+            $(element).show();
+            childManager.show();
+        },
 
+        hide: function () {
+            $(element).hide();
+            childManager.hide();
+        }
     };
 
 }

--- a/problem_builder/public/js/step.js
+++ b/problem_builder/public/js/step.js
@@ -105,12 +105,18 @@ function MentoringStepBlock(runtime, element) {
             return $('.sb-step', element).data('has-question');
         },
 
-        show: function () {
+        /**
+         * Shows a step, updating all children. 
+         */
+        showStep: function () {
             $(element).show();
             childManager.show();
         },
 
-        hide: function () {
+        /**
+         * Hides a step, updating all children.
+         */
+        hideStep: function () {
             $(element).hide();
             childManager.hide();
         }

--- a/problem_builder/public/js/step.js
+++ b/problem_builder/public/js/step.js
@@ -5,7 +5,7 @@ function MentoringStepBlock(runtime, element) {
     var submitXHR, resultsXHR,
         message = $(element).find('.sb-step-message');
     
-    var childManager = new ProblemBuilderUtilLMS.ChildManager(element, runtime);
+    var childManager = new ProblemBuilderStepUtil.ChildManager(element, runtime);
 
     function callIfExists(obj, fn) {
         if (typeof obj !== 'undefined' && typeof obj[fn] == 'function') {

--- a/problem_builder/public/js/step_util.js
+++ b/problem_builder/public/js/step_util.js
@@ -111,7 +111,7 @@
 
     }
 
-    window.ProblemBuilderUtilLMS = {
+    window.ProblemBuilderStepUtil = {
 
         ChildManager: ChildManager
 

--- a/problem_builder/tests/integration/test_step_builder.py
+++ b/problem_builder/tests/integration/test_step_builder.py
@@ -624,9 +624,7 @@ class StepBuilderTest(MentoringAssessmentBaseTest, MultipleSliderBlocksTestMixin
 
     @data(True, False)
     def test_conditional_messages(self, include_messages):
-        """
-        Test that conditional messages in the review step are visible or not, as appropriate.
-        """
+        # Test that conditional messages in the review step are visible or not, as appropriate.
         max_attempts = 3
         extended_feedback = False
         params = {


### PR DESCRIPTION
This is a follow up on: #114 and #112. 

## Course set up

What you need is a course where on a step you have a video, and then you can to the next step (you should still hear the video on that next step --- which is the error). 

1. Create a course with three sections, each containing a single subsection and a single unit. 
2. First unit contains following steps: 

  a. A step with Video Block and a question
  b. A step with HTML Block with a youtube video and a question. Example embedding code: `<iframe width="420" height="315" src="https://www.youtube.com/embed/QH2-TGUlwu4" frameborder="0" allowfullscreen></iframe>`
 c. A step with a question (no videos!)
 d. A review step with a HTML with a youtube video, and other review elements. 

3. Second unit contains
 
 a. A step with OOyala video and a question (OOyala set-up is described in the OC-1441 issue)
 b. A step with a question 
 c. A review step  

4. Third unit contains (note that having the same Ooyala video on a two steps in single unit might not work. 

 a. A step with a question 
 a. A review step with a HTML block with ooyala video embedded. 

##  Verification instructions

1. Please note that OOyala video needs to be manually started by pasting a snippet to a javascript console --- snippet is attached above the video, and looks like that: `OO.ready(function() { OO.Player.create('xxx', 'yyy_zzz'); });`. After you start the video it should work as it was started "normally" so tests are still valid. 
3. Go to the block with video, start the video and wait until it loads, fill in the quiz and go to next step. Note that you still hear video music in the background. 
4. Check the same with the OOyala video subsection. 
5. Note that on re-entering the ooyala videos on review step the video doesn't display itself, this is due to the fact that html of [review elements is replaced when displaying this step](https://github.com/open-craft/problem-builder/blob/master/problem_builder/public/js/mentoring_with_steps.js#L92) (this is current behaviour in master), which doesn't play well with ooyala . 

## Testing instructions

For each of the units: 

1. Checkout this branch.
2. Go to video and block, start the video and wait until it loads, fill in the quiz and go to next step. Note that the video is no longer playing in the background. 
3. Fill in rest of the quiz, watch the review step, and go back to the video step. Verify that video is still working properly. 
4. Check if: 

 a. Reloading a page with a video works
 b. Video works on first visit
 c. Video works when re-visiting
 d. Video XBlock rememebers it's position 

5. Note that Ooyala videos in review steps are still broken. 
