### PR TITLE
Hide MRQ question-level feedback on return.

### DIFF
--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -60,7 +60,7 @@ log = logging.getLogger(__name__)
 loader = ResourceLoader(__name__)
 
 _default_options_config = {
-    'pb_mcq_hide_previous_answer': False,
+    'pb_mcq_hide_previous_answer': False,  # this works for both MCQs and MRQs.
     'pb_hide_feedback_if_attempts_remain': False,
 }
 

--- a/problem_builder/public/js/questionnaire.js
+++ b/problem_builder/public/js/questionnaire.js
@@ -206,8 +206,6 @@ function MRQBlock(runtime, element) {
 
             var messageView = MessageView(element, mentoring);
 
-            display_message(result.message, messageView, options.checkmark);
-
             var questionnaireDOM = $('fieldset.questionnaire', element);
             var data = questionnaireDOM.data();
             var hide_results = (data.hide_results === 'True' ||
@@ -215,6 +213,10 @@ function MRQBlock(runtime, element) {
             // hide_prev_answer should only take effect when we initially render (previous) results,
             // so set hide_prev_answer to False after initial render.
             questionnaireDOM.data('hide_prev_answer', 'False');
+
+            if (!hide_results) {
+                display_message(result.message, messageView, options.checkmark);
+            }
 
             $.each(result.choices, function(index, choice) {
                 var choiceInputDOM = $('.choice input[value='+choice.value+']', element);

--- a/problem_builder/tests/integration/xml_templates/feedback_persistence.xml
+++ b/problem_builder/tests/integration/xml_templates/feedback_persistence.xml
@@ -1,5 +1,5 @@
 <vertical_demo>
-    <problem-builder url_name="feedback" enforce_dependency="false">
+    <problem-builder url_name="feedback">
         <pb-answer name="feedback_answer_1" />
 
         <pb-mcq name="feedback_mcq_2" question="Do you like this MCQ?" correct_choices='["yes"]'>

--- a/problem_builder/tests/integration/xml_templates/feedback_persistence_mcq_general_feedback.xml
+++ b/problem_builder/tests/integration/xml_templates/feedback_persistence_mcq_general_feedback.xml
@@ -1,7 +1,7 @@
 <vertical_demo>
-    <problem-builder url_name="feedback_tips" enforce_dependency="false">
+    <problem-builder url_name="mcq_general_feedback">
 
-        <pb-mcq name="feedback_mcq_2" question="Do you like this MCQ?" correct_choices='["yes"]' message="Question level Feedback">
+        <pb-mcq name="feedback_questionnaire" question="Do you like this MCQ?" correct_choices='["yes"]' message="Question level Feedback">
             <pb-choice value="yes">Yes</pb-choice>
             <pb-choice value="maybenot">Maybe not</pb-choice>
             <pb-choice value="understand">I don't understand</pb-choice>

--- a/problem_builder/tests/integration/xml_templates/feedback_persistence_mcq_general_feedback_and_tips.xml
+++ b/problem_builder/tests/integration/xml_templates/feedback_persistence_mcq_general_feedback_and_tips.xml
@@ -1,7 +1,7 @@
 <vertical_demo>
-    <problem-builder url_name="mcq_tips">
+    <problem-builder url_name="mcq_general_feedback_and_tips">
 
-        <pb-mcq name="feedback_questionnaire" question="Do you like this MCQ?" correct_choices='["yes"]'>
+        <pb-mcq name="feedback_questionnaire" question="Do you like this MCQ?" correct_choices='["yes"]' message="Question level Feedback">
             <pb-choice value="yes">Yes</pb-choice>
             <pb-choice value="maybenot">Maybe not</pb-choice>
             <pb-choice value="understand">I don't understand</pb-choice>

--- a/problem_builder/tests/integration/xml_templates/feedback_persistence_mcq_no_feedback.xml
+++ b/problem_builder/tests/integration/xml_templates/feedback_persistence_mcq_no_feedback.xml
@@ -1,14 +1,10 @@
 <vertical_demo>
-    <problem-builder url_name="mcq_tips">
+    <problem-builder url_name="mcq_no_feedback">
 
         <pb-mcq name="feedback_questionnaire" question="Do you like this MCQ?" correct_choices='["yes"]'>
             <pb-choice value="yes">Yes</pb-choice>
             <pb-choice value="maybenot">Maybe not</pb-choice>
             <pb-choice value="understand">I don't understand</pb-choice>
-
-            <pb-tip values='["yes"]'>Great!</pb-tip>
-            <pb-tip values='["maybenot"]'>Ah, damn.</pb-tip>
-            <pb-tip values='["understand"]'><div id="test-custom-html">Really?</div></pb-tip>
         </pb-mcq>
 
     </problem-builder>

--- a/problem_builder/tests/integration/xml_templates/feedback_persistence_mrq_general_feedback.xml
+++ b/problem_builder/tests/integration/xml_templates/feedback_persistence_mrq_general_feedback.xml
@@ -1,0 +1,12 @@
+<vertical_demo>
+    <problem-builder url_name="mrq_general_feedback">
+
+        <pb-mrq name="feedback_questionnaire" question="What do you like in this MRQ?" required_choices='["elegance","beauty","gracefulness"]' message="Question level feedback">
+            <pb-choice value="elegance">Its elegance</pb-choice>
+            <pb-choice value="beauty">Its beauty</pb-choice>
+            <pb-choice value="gracefulness">Its gracefulness</pb-choice>
+            <pb-choice value="bugs">Its bugs</pb-choice>
+        </pb-mrq>
+
+    </problem-builder>
+</vertical_demo>

--- a/problem_builder/tests/integration/xml_templates/feedback_persistence_mrq_general_feedback_and_tips.xml
+++ b/problem_builder/tests/integration/xml_templates/feedback_persistence_mrq_general_feedback_and_tips.xml
@@ -1,0 +1,17 @@
+<vertical_demo>
+    <problem-builder url_name="mrq_general_feedback_and_tips">
+
+        <pb-mrq name="feedback_questionnaire" question="What do you like in this MRQ?" required_choices='["elegance","beauty","gracefulness"]' message="Question level feedback">
+            <pb-choice value="elegance">Its elegance</pb-choice>
+            <pb-choice value="beauty">Its beauty</pb-choice>
+            <pb-choice value="gracefulness">Its gracefulness</pb-choice>
+            <pb-choice value="bugs">Its bugs</pb-choice>
+
+            <pb-tip values='["elegance"]'>This is something everyone has to like about this MRQ</pb-tip>
+            <pb-tip values='["beauty"]'>This is something everyone has to like about beauty</pb-tip>
+            <pb-tip values='["gracefulness"]'>This MRQ is indeed very graceful</pb-tip>
+            <pb-tip values='["bugs"]'>Nah, there aren't any!</pb-tip>
+        </pb-mrq>
+
+    </problem-builder>
+</vertical_demo>

--- a/problem_builder/tests/integration/xml_templates/feedback_persistence_mrq_no_feedback.xml
+++ b/problem_builder/tests/integration/xml_templates/feedback_persistence_mrq_no_feedback.xml
@@ -1,0 +1,12 @@
+<vertical_demo>
+    <problem-builder url_name="mrq_no_feedback">
+
+        <pb-mrq name="feedback_questionnaire" question="What do you like in this MRQ?" required_choices='["elegance","beauty","gracefulness"]'>
+            <pb-choice value="elegance">Its elegance</pb-choice>
+            <pb-choice value="beauty">Its beauty</pb-choice>
+            <pb-choice value="gracefulness">Its gracefulness</pb-choice>
+            <pb-choice value="bugs">Its bugs</pb-choice>
+        </pb-mrq>
+
+    </problem-builder>
+</vertical_demo>

--- a/problem_builder/tests/integration/xml_templates/feedback_persistence_mrq_tips.xml
+++ b/problem_builder/tests/integration/xml_templates/feedback_persistence_mrq_tips.xml
@@ -1,0 +1,17 @@
+<vertical_demo>
+    <problem-builder url_name="mrq_tips">
+
+        <pb-mrq name="feedback_questionnaire" question="What do you like in this MRQ?" required_choices='["elegance","beauty","gracefulness"]'>
+            <pb-choice value="elegance">Its elegance</pb-choice>
+            <pb-choice value="beauty">Its beauty</pb-choice>
+            <pb-choice value="gracefulness">Its gracefulness</pb-choice>
+            <pb-choice value="bugs">Its bugs</pb-choice>
+
+            <pb-tip values='["elegance"]'>This is something everyone has to like about this MRQ</pb-tip>
+            <pb-tip values='["beauty"]'>This is something everyone has to like about beauty</pb-tip>
+            <pb-tip values='["gracefulness"]'>This MRQ is indeed very graceful</pb-tip>
+            <pb-tip values='["bugs"]'>Nah, there aren't any!</pb-tip>
+        </pb-mrq>
+
+    </problem-builder>
+</vertical_demo>


### PR DESCRIPTION
When the pb_mcq_hide_previous_answer is set to True, question-level feedback should not be displayed when user returns to the page.

cf. [MCKIN-3999](https://edx-wiki.atlassian.net/browse/MCKIN-3999)

*Test Instructions*

1. Create a new subunit containing one problem builder MRQ question unit, and another arbitrary unit. Make sure to put some content into the "Message (General feedback provided when submitting)" field of the MRQ.
2. Enable `pb_mcq_hide_previous_answer` in your `XBLOCK_SETTINGS`.
3. Go to the unit with the MRQ question, fill it in, and submit. You should see the general feedback message.
4. Go to the next unit, then come back to the unit with the MRQ question.
5. General feedback message should be hidden.