### PR TITLE
Fix mako template context error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
     - "pip install -r requirements.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt"
-    - "pip uninstall -y xblock-problem-builder && python setup.py sdist && pip install dist/xblock-problem-builder-2.0.3.tar.gz"
+    - "pip uninstall -y xblock-problem-builder && python setup.py sdist && pip install dist/xblock-problem-builder-2.0.4.tar.gz"
     - "pip install -r test_requirements.txt"
     - "mkdir var"
 script:

--- a/problem_builder/answer.py
+++ b/problem_builder/answer.py
@@ -164,7 +164,7 @@ class AnswerBlock(AnswerMixin, StepMixin, StudioEditableXBlockMixin, XBlock):
 
     def mentoring_view(self, context=None):
         """ Render this XBlock within a mentoring block. """
-        context = context or {}
+        context = context.copy() if context else {}
         context['self'] = self
         context['hide_header'] = context.get('hide_header', False) or not self.show_title
         html = loader.render_template('templates/html/answer_editable.html', context)
@@ -266,7 +266,7 @@ class AnswerRecapBlock(AnswerMixin, StudioEditableXBlockMixin, XBlock):
 
     def mentoring_view(self, context=None):
         """ Render this XBlock within a mentoring block. """
-        context = context or {}
+        context = context.copy() if context else {}
         context['title'] = self.display_name
         context['description'] = self.description
         context['student_input'] = self.student_input

--- a/problem_builder/step.py
+++ b/problem_builder/step.py
@@ -95,12 +95,12 @@ class StepMixin(object):
         return self._(u"Question")
 
     def author_view(self, context):
-        context = context or {}
+        context = context.copy() if context else {}
         context['hide_header'] = True
         return self.mentoring_view(context)
 
     def author_preview_view(self, context):
-        context = context or {}
+        context = context.copy() if context else {}
         context['hide_header'] = True
         return self.student_view(context)
 

--- a/problem_builder/table.py
+++ b/problem_builder/table.py
@@ -70,7 +70,7 @@ class MentoringTableBlock(StudioEditableXBlockMixin, StudioContainerXBlockMixin,
     has_children = True
 
     def student_view(self, context):
-        context = context or {}
+        context = context.copy() if context else {}
         fragment = Fragment()
         header_values = []
         content_values = []
@@ -136,7 +136,7 @@ class MentoringTableColumn(StudioEditableXBlockMixin, StudioContainerXBlockMixin
 
     def mentoring_view(self, context=None):
         """ Render this XBlock within a mentoring block. """
-        context = context or {}
+        context = context.copy() if context else {}
         fragment = Fragment()
         for child_id in self.children:
             child = self.runtime.get_block(child_id)

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='2.0.3',
+    version='2.0.4',
     description='XBlock - Problem Builder',
     packages=['problem_builder', 'problem_builder.v1'],
     install_requires=[


### PR DESCRIPTION
This fixes https://openedx.atlassian.net/browse/TNL-4901 by backporting the already-existing fix that was on the `master` branch.

The problem was that `mentoring_view` was inadvertently modifying its `context` parameter.

Note 1: @adampalay tested and confirmed this fixes the TNL-4901 issue.

Note 2: on this branch, CircleCI is expected to fail (it's only configured on master), but TravisCI is required to pass - so the tests are fine.