### PR TITLE
Update xblock-utils to v1.0.3.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,8 @@ machine:
 dependencies:
   override:
     - "pip install -U pip wheel"
+    # Temporarily pin setuptools to a specific version.
+    # See commit message of https://github.com/open-craft/problem-builder/commit/51277a34fb426724616618c1afdb893ab2de4c6b for more info:
     - "pip install setuptools==24.3.1"
     - "pip install -e git://github.com/edx/xblock-sdk.git@bddf9f4a2c6e4df28a411c8f632cc2250170ae9d#egg=xblock-sdk"
     - "pip install -r requirements.txt"

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,8 @@ machine:
     version: 2.7.10
 dependencies:
   override:
-    - "pip install -U pip wheel setuptools"
+    - "pip install -U pip wheel"
+    - "pip install setuptools==24.3.1"
     - "pip install -e git://github.com/edx/xblock-sdk.git@bddf9f4a2c6e4df28a411c8f632cc2250170ae9d#egg=xblock-sdk"
     - "pip install -r requirements.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ddt
 mock
 unicodecsv==0.9.4
--e git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils
+-e git+https://github.com/edx/xblock-utils.git@v1.0.3#egg=xblock-utils
 -e .


### PR DESCRIPTION
New version includes fixes from https://github.com/edx/xblock-utils/pull/38 and https://github.com/edx/xblock-utils/pull/39.

Follow-up PR for [OC-1819](https://tasks.opencraft.com/browse/OC-1819) (candidate task).

Also fixes an issue affecting dependency installation for CircleCI builds for problem-builder. See the commit message of https://github.com/open-craft/problem-builder/pull/120/commits/51277a34fb426724616618c1afdb893ab2de4c6b for details.