### PR TITLE
Remove "Message (Assessment Review)" from Problem Builder in Studio

### DIFF
--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -820,7 +820,11 @@ class MentoringBlock(BaseMentoringBlock, StudioContainerXBlockMixin, StepParentM
         fragment = Fragment(u'<div class="mentoring">')  # This DIV is needed for CSS to apply to the previews
         self.render_children(context, fragment, can_reorder=True, can_add=False)
         fragment.add_content(u'</div>')
-        fragment.add_content(loader.render_template('templates/html/mentoring_add_buttons.html', {}))
+
+        # Show buttons to add review-related child blocks only in assessment mode.
+        fragment.add_content(loader.render_template('templates/html/mentoring_add_buttons.html', {
+            "show_review": self.is_assessment,
+        }))
         fragment.add_content(loader.render_template('templates/html/mentoring_url_name.html', {
             "url_name": self.url_name
         }))

--- a/problem_builder/message.py
+++ b/problem_builder/message.py
@@ -88,16 +88,14 @@ class MentoringMessageBlock(XBlock, StudioEditableXBlockMixin, XBlockWithTransla
         },
         "on-assessment-review-question": {
             "display_name": _(u"Study tips if this question was wrong"),
-            "long_display_name": _(u"Study tips shown during assessment review if wrong"),
+            "long_display_name": _(u"Study tips shown if question was answered incorrectly"),
             "default": _(
                 u"Review ____."
             ),
             "description": _(
-                u"In assessment mode, this message will be shown when the student is reviewing "
+                u"This message will be shown when the student is reviewing "
                 "their answers to the assessment, if the student got this specific question "
-                "wrong and is allowed to try again. "
-                "This message is ignored in standard mode and is not shown if the student has "
-                "used up all of their allowed attempts."
+                "wrong and is allowed to try again."
             ),
         },
     }

--- a/problem_builder/public/css/problem-builder-edit.css
+++ b/problem_builder/public/css/problem-builder-edit.css
@@ -28,9 +28,11 @@
 .xblock[data-block-type=step-builder] .add-xblock-component .new-component .new-component-type .add-xblock-component-button,
 .xblock[data-block-type=problem-builder] .add-xblock-component .new-component .new-component-type .add-xblock-component-button,
 .xblock[data-block-type=mentoring] .add-xblock-component .new-component .new-component-type .add-xblock-component-button {
-  width: 200px;
-  height: 30px;
+  width: auto;
+  height: auto;
   line-height: 30px;
+  padding-left: 1em;
+  padding-right: 1em;
 }
 
 .xblock[data-block-type=sb-plot] .add-xblock-component .new-component .new-component-type .add-xblock-component-button.disabled,

--- a/problem_builder/public/css/questionnaire-edit.css
+++ b/problem_builder/public/css/questionnaire-edit.css
@@ -1,8 +1,10 @@
 /* Custom appearance for our "Add" buttons */
 .xblock .add-xblock-component .new-component .new-component-type .add-xblock-component-button {
-  width: 200px;
-  height: 30px;
+  width: auto;
+  height: auto;
   line-height: 30px;
+  padding-left: 1em;
+  padding-right: 1em;
 }
 
 .xblock .add-xblock-component .new-component .new-component-type .add-xblock-component-button.disabled,

--- a/problem_builder/questionnaire.py
+++ b/problem_builder/questionnaire.py
@@ -158,7 +158,14 @@ class QuestionnaireAbstractBlock(
         Add some HTML to the author view that allows authors to add choices and tips.
         """
         fragment = self.get_author_edit_view_fragment(context)
-        fragment.add_content(loader.render_template('templates/html/questionnaire_add_buttons.html', {}))
+
+        # Let the parent block determine whether to display buttons to add review-related child blocks.
+        # * Problem Builder units use MentoringBlock parent components, which define an 'is_assessment' property,
+        #   indicating whether the (deprecated) assessment mode is enabled.
+        # * Step Builder units can show review components in the Review Step.
+        fragment.add_content(loader.render_template('templates/html/questionnaire_add_buttons.html', {
+            'show_review': getattr(self.get_parent(), 'is_assessment', True),
+        }))
         fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/problem-builder.css'))
         fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/questionnaire-edit.css'))
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/util.js'))

--- a/problem_builder/templates/html/mentoring_add_buttons.html
+++ b/problem_builder/templates/html/mentoring_add_buttons.html
@@ -15,7 +15,9 @@
       <li><a href="#" class="single-template add-xblock-component-button" data-category="pb-message" data-boilerplate="completed">{% trans "Message (Complete)" %}</a></li>
       <li><a href="#" class="single-template add-xblock-component-button" data-category="pb-message" data-boilerplate="incomplete">{% trans "Message (Incomplete)" %}</a></li>
       <li><a href="#" class="single-template add-xblock-component-button" data-category="pb-message" data-boilerplate="max_attempts_reached">{% trans "Message (Max # Attempts)" %}</a></li>
+      {% if show_review %}
       <li><a href="#" class="single-template add-xblock-component-button" data-category="pb-message" data-boilerplate="on-assessment-review">{% trans "Message (Assessment Review)" %}</a></li>
+      {% endif %}
     </ul>
   </div>
 </div>

--- a/problem_builder/templates/html/questionnaire_add_buttons.html
+++ b/problem_builder/templates/html/questionnaire_add_buttons.html
@@ -5,7 +5,9 @@
     <ul class="new-component-type">
       <li><a href="#" class="single-template add-xblock-component-button" data-category="pb-choice" data-boilerplate="studio_default">{% trans "Add Custom Choice" %}</a></li>
       <li><a href="#" class="single-template add-xblock-component-button" data-category="pb-tip">{% trans "Add Tip" %}</a></li>
-      <li><a href="#" class="single-template add-xblock-component-button" data-category="pb-message" data-boilerplate="on-assessment-review-question">{% trans "Message (Assessment Review)" %}</a></li>
+      {% if show_review %}
+      <li><a href="#" class="single-template add-xblock-component-button" data-category="pb-message" data-boilerplate="on-assessment-review-question">{% trans "Message (Review)" %}</a></li>
+      {% endif %}
     </ul>
   </div>
 </div>


### PR DESCRIPTION
Removes the ability for Studio users to add `Message (Assessment Review)` components to Problem Builder units, unless the legacy "assessment mode" is enabled.

Studio users may still add `Message (Review)` components to Step Builder Questionnaire components, and to legacy "assessment mode" Problem Builder Questionnaire components, but not to new Problem Builder units.

Also fixes the style issues these buttons by allowing the buttons to use `width: auto` and `height: auto` to accommodate varied text lengths.

**Screenshots**:

* `Message (Assessment Review)` removed from Problem Builder:
    ![problem builder standard](https://cloud.githubusercontent.com/assets/7556571/18901233/61eca3ea-8588-11e6-85c3-74ed24edf8bf.png)
* `Message (Assessment Review)` style fixed in Problem Builder (legacy assessment mode):
    ![problem builder assessment](https://cloud.githubusercontent.com/assets/7556571/18901266/b31aa8ac-8588-11e6-9113-095ce76463a7.png)
* `Message (Assessment Review)` removed from Problem Builder Questionnaires:
   ![problem builder questionnaire standard](https://cloud.githubusercontent.com/assets/7556571/18901242/745933cc-8588-11e6-8f2e-cd87423f0b35.png)
* `Message (Assessment Review)` style fixed in Step Builder and Problem Builder (legacy assessment mode) Questionnaires:
    ![questionnaire](https://cloud.githubusercontent.com/assets/7556571/18901297/f46d2d0c-8588-11e6-8db3-b523313a9f4e.png)

**Sandbox URL**:

Installed 48db943.

* LMS: http://pb-pr122.sandbox.opencraft.hosting/
* Studio: http://studio-pb-pr122.sandbox.opencraft.hosting/

**Partner information**: 3rd party-hosted open edX instance

**Testing instructions**:

1. Login as the `staff` user to the [sandbox Studio Problem Builder Demos course](http://studio-pb-pr122.sandbox.opencraft.hosting/course/course-v1:OpenCraft+PB+2016). 
1. From the `Introduction > Overview` section, view the `Problem Builder` unit, and click `View` to see its block components.
    * Note that the `Message (Assessment Review)` button is not present in the list of Components.
1. Click `View` under `Problem Builder` `Question 1`.  
    * Note that the `Message (Review)` button is not present in the list of options.
1. From the `Introduction > Overview` section, view the `Problem Builder Assessment Mode` unit, and click `View` to see its block components.  
    * Note that the `Message (Assessment Review)` button is present.  It is greyed out because this message type has already been added to the unit.
    * Note the button styles have changed to accommodate the button text length.
1.  Click `View` under `Problem Builder Assessment Mode` `Question 1`.  
    * Note that the `Message (Review)` button is present in the list of options.  It is greyed out because this message type has already been added to the unit.
    * Note the button styles have changed to accommodate the button text length.
    * Note the updated help text on the `Message (Review)` component.
1. From the `Introduction > Overview` section, view the `Step Builder` unit, and click `View` to see its block components.  
1. Click `View` under `Step Builder` `Question 3`.
    * Note that the `Message (Review)` button is present in the list of options.  It is greyed out because this message type has already been added to the unit.
    * Note the button styles have changed to accommodate the button text length.
    * Note the updated help text on the `Message (Review)` component.
15. View the [live course in the LMS](http://pb-pr122.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+PB+2016/courseware/b7da9f976d844803b359de901e8d7dfe/b665ced314434eb8838fa6c5e4420a02/).
16. Work through the units in `Introduction > Overview`, and note that the assessment review functionality is unaffected.

**Reviewers**
- [x] @itsjeyd 