### PR TITLE
Uses the same import path for instructor_task.models as edxapp

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ dependencies:
     - "pip install -r requirements.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt"
-    - "pip uninstall -y xblock-problem-builder && python setup.py sdist && pip install dist/xblock-problem-builder-2.6.0.tar.gz"
+    - "pip uninstall -y xblock-problem-builder && python setup.py sdist && pip install dist/xblock-problem-builder-2.6.1.tar.gz"
     - "pip install -r test_requirements.txt"
     - "mkdir var"
 test:

--- a/problem_builder/instructor_tool.py
+++ b/problem_builder/instructor_tool.py
@@ -241,7 +241,7 @@ class InstructorToolBlock(XBlock):
         # Unfortunately this is a bit inefficient due to the ReportStore API
         if not self.last_export_result or self.last_export_result['error'] is not None:
             return None
-        from instructor_task.models import ReportStore
+        from lms.djangoapps.instructor_task.models import ReportStore
         report_store = ReportStore.from_config(config_name='GRADES_DOWNLOAD')
         course_key = getattr(self.scope_ids.usage_id, 'course_key', None)
         return dict(report_store.links_for(course_key)).get(self.last_export_result['report_filename'])

--- a/problem_builder/tasks.py
+++ b/problem_builder/tasks.py
@@ -5,7 +5,7 @@ import time
 
 from celery.task import task
 from celery.utils.log import get_task_logger
-from instructor_task.models import ReportStore
+from lms.djangoapps.instructor_task.models import ReportStore
 from opaque_keys.edx.keys import CourseKey
 from student.models import user_by_anonymous_id
 from xmodule.modulestore.django import modulestore

--- a/problem_builder/tests/integration/test_instructor_tool.py
+++ b/problem_builder/tests/integration/test_instructor_tool.py
@@ -62,8 +62,10 @@ class InstructorToolTest(SeleniumXBlockTest):
 
     @patch.dict('sys.modules', {
         'problem_builder.tasks': MockTasksModule(successful=True),
-        'instructor_task': True,
-        'instructor_task.models': MockInstructorTaskModelsModule(),
+        'lms': True,
+        'lms.djangoapps': True,
+        'lms.djangoapps.instructor_task': True,
+        'lms.djangoapps.instructor_task.models': MockInstructorTaskModelsModule(),
     })
     @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
     def test_export_field_container_width(self):
@@ -79,8 +81,10 @@ class InstructorToolTest(SeleniumXBlockTest):
 
     @patch.dict('sys.modules', {
         'problem_builder.tasks': MockTasksModule(successful=True),
-        'instructor_task': True,
-        'instructor_task.models': MockInstructorTaskModelsModule(),
+        'lms': True,
+        'lms.djangoapps': True,
+        'lms.djangoapps.instructor_task': True,
+        'lms.djangoapps.instructor_task.models': MockInstructorTaskModelsModule(),
     })
     @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
     def test_root_block_select_width(self):
@@ -96,8 +100,10 @@ class InstructorToolTest(SeleniumXBlockTest):
 
     @patch.dict('sys.modules', {
         'problem_builder.tasks': MockTasksModule(successful=True),
-        'instructor_task': True,
-        'instructor_task.models': MockInstructorTaskModelsModule(),
+        'lms': True,
+        'lms.djangoapps': True,
+        'lms.djangoapps.instructor_task': True,
+        'lms.djangoapps.instructor_task.models': MockInstructorTaskModelsModule(),
     })
     @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
     def test_data_export_delete(self):
@@ -126,8 +132,10 @@ class InstructorToolTest(SeleniumXBlockTest):
 
     @patch.dict('sys.modules', {
         'problem_builder.tasks': MockTasksModule(successful=True),
-        'instructor_task': True,
-        'instructor_task.models': MockInstructorTaskModelsModule(),
+        'lms': True,
+        'lms.djangoapps': True,
+        'lms.djangoapps.instructor_task': True,
+        'lms.djangoapps.instructor_task.models': MockInstructorTaskModelsModule(),
     })
     @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
     def test_data_export_success(self):
@@ -164,8 +172,10 @@ class InstructorToolTest(SeleniumXBlockTest):
 
     @patch.dict('sys.modules', {
         'problem_builder.tasks': MockTasksModule(successful=False),
-        'instructor_task': True,
-        'instructor_task.models': MockInstructorTaskModelsModule(),
+        'lms': True,
+        'lms.djangoapps': True,
+        'lms.djangoapps.instructor_task': True,
+        'lms.djangoapps.instructor_task.models': MockInstructorTaskModelsModule(),
     })
     @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
     def test_data_export_error(self):
@@ -196,8 +206,10 @@ class InstructorToolTest(SeleniumXBlockTest):
 
     @patch.dict('sys.modules', {
         'problem_builder.tasks': MockTasksModule(successful=True),
-        'instructor_task': True,
-        'instructor_task.models': MockInstructorTaskModelsModule(),
+        'lms': True,
+        'lms.djangoapps': True,
+        'lms.djangoapps.instructor_task': True,
+        'lms.djangoapps.instructor_task.models': MockInstructorTaskModelsModule(),
     })
     @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
     def test_pagination_no_results(self):
@@ -230,8 +242,10 @@ class InstructorToolTest(SeleniumXBlockTest):
                 'Test section', 'Test subsection', 'Test unit',
                 'Test type', 'Test question', 'Test answer', 'Test username'
             ]]),
-        'instructor_task': True,
-        'instructor_task.models': MockInstructorTaskModelsModule(),
+        'lms': True,
+        'lms.djangoapps': True,
+        'lms.djangoapps.instructor_task': True,
+        'lms.djangoapps.instructor_task.models': MockInstructorTaskModelsModule(),
     })
     @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
     def test_pagination_single_result(self):
@@ -270,8 +284,10 @@ class InstructorToolTest(SeleniumXBlockTest):
                 'Test section', 'Test subsection', 'Test unit',
                 'Test type', 'Test question', 'Test answer', 'Test username'
             ] for _ in range(PAGE_SIZE*3)]),
-        'instructor_task': True,
-        'instructor_task.models': MockInstructorTaskModelsModule(),
+        'lms': True,
+        'lms.djangoapps': True,
+        'lms.djangoapps.instructor_task': True,
+        'lms.djangoapps.instructor_task.models': MockInstructorTaskModelsModule(),
     })
     @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
     def test_pagination_multiple_results(self):

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='2.6.0',
+    version='2.6.1',
     description='XBlock - Problem Builder',
     packages=['problem_builder', 'problem_builder.v1'],
     install_requires=[


### PR DESCRIPTION
Fixes celery task error (ref [TNL-5903](https://openedx.atlassian.net/browse/TNL-5903)):

> RuntimeError: Conflicting 'instructortask' models in application 'instructor_task': <class 'lms.djangoapps.instructor_task.models.InstructorTask'> and <class 'instructor_task.models.InstructorTask'>.

*Testing instructions*

1. Ensure your devstack is updated to current `master`.  The commit that introduced the conflict was [54d34e8](https://github.com/edx/edx-platform/commit/54d34e834d5a108f03db59a1e0f6b97e2afae7d0).
1. Create a course, and import [course.99Ob05.tar.gz](https://github.com/open-craft/problem-builder/files/575891/course.99Ob05.tar.gz).
1. Visit the Features > Instructor Tool unit, and note that you're able to filter and download data.

*Reviewers*
- [x] haikuginger