### PR TITLE
2.6.2 Instructor Tool uses the Course Blocks REST API

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ dependencies:
     - "pip install -r requirements.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt"
-    - "pip uninstall -y xblock-problem-builder && python setup.py sdist && pip install dist/xblock-problem-builder-2.6.1.tar.gz"
+    - "pip uninstall -y xblock-problem-builder && python setup.py sdist && pip install dist/xblock-problem-builder-2.6.2.tar.gz"
     - "pip install -r test_requirements.txt"
     - "mkdir var"
 test:

--- a/problem_builder/answer.py
+++ b/problem_builder/answer.py
@@ -260,6 +260,13 @@ class AnswerBlock(SubmittingXBlockMixin, AnswerMixin, QuestionMixin, StudioEdita
             return {'data': {'name': uuid.uuid4().hex[:7]}}
         return {'metadata': {}, 'data': {}}
 
+    def student_view_data(self):
+        """
+        Returns a JSON representation of the student_view of this XBlock,
+        retrievable from the Course Block API.
+        """
+        return {'question': self.question}
+
 
 @XBlock.needs("i18n")
 class AnswerRecapBlock(AnswerMixin, StudioEditableXBlockMixin, XBlock):

--- a/problem_builder/instructor_tool.py
+++ b/problem_builder/instructor_tool.py
@@ -34,6 +34,10 @@ loader = ResourceLoader(__name__)
 
 PAGE_SIZE = 15
 
+# URL Path to the Course Blocks REST API.
+# Note that we add a trailing slash to avoid the API's redirect hit.
+COURSE_BLOCKS_API = '/api/courses/v1/blocks/'
+
 
 # Make '_' a no-op so we can scrape strings
 def _(text):
@@ -135,12 +139,11 @@ class InstructorToolBlock(XBlock):
             _('Long Answer'): 'AnswerBlock',
         }
 
-        flat_block_tree = self._build_course_tree()
-
-        html = loader.render_template(
-            'templates/html/instructor_tool.html',
-            {'block_choices': block_choices, 'block_tree': flat_block_tree}
-        )
+        html = loader.render_template('templates/html/instructor_tool.html', {
+            'block_choices': block_choices,
+            'course_blocks_api': COURSE_BLOCKS_API,
+            'root_block_id': unicode(getattr(self.runtime, 'course_id', 'course_id')),
+        })
         fragment = Fragment(html)
         fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/instructor_tool.css'))
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/instructor_tool.js'))
@@ -149,91 +152,6 @@ class InstructorToolBlock(XBlock):
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/vendor/backbone.paginator.min.js'))
         fragment.initialize_js('InstructorToolBlock')
         return fragment
-
-    def _build_course_tree(self):
-        """
-        Return flat tree of blocks belonging to this block's parent course.
-        """
-        eligible_block_types = ('pb-mcq', 'pb-rating', 'pb-answer')
-        flat_block_tree = []
-
-        def get_block_id(block):
-            """
-            Return ID of `block`, taking into account needs of both LMS/CMS and workbench runtimes.
-            """
-            usage_id = block.scope_ids.usage_id
-            # Try accessing block ID. If usage_id does not have it, return usage_id itself
-            return unicode(getattr(usage_id, 'block_id', usage_id))
-
-        def get_block_name(block):
-            """
-            Return name of `block`.
-
-            Try attributes in the following order:
-              - block.question
-              - block.name (fallback for old courses)
-              - block.display_name
-              - block ID
-            """
-            for attribute in ('question', 'name', 'display_name'):
-                if getattr(block, attribute, None):
-                    return getattr(block, attribute, None)
-            return get_block_id(block)
-
-        def get_block_type(block):
-            """
-            Return type of `block`, taking into account different key styles that might be in use.
-            """
-            try:
-                block_type = block.runtime.id_reader.get_block_type(block.scope_ids.def_id)
-            except AttributeError:
-                block_type = block.runtime.id_reader.get_block_type(block.scope_ids.usage_id)
-            return block_type
-
-        def build_tree(block, ancestors):
-            """
-            Build up a tree of information about the XBlocks descending from `block`.
-            """
-            block_id = get_block_id(block)
-            block_name = get_block_name(block)
-            block_type = get_block_type(block)
-            if block_type != 'pb-choice':
-                eligible = block_type in eligible_block_types
-                if eligible:
-                    # If this block is a question whose answers we can export,
-                    # we mark all of its ancestors as exportable too
-                    if ancestors and not ancestors[-1]["eligible"]:
-                        for ancestor in ancestors:
-                            ancestor["eligible"] = True
-
-                new_entry = {
-                    "depth": len(ancestors),
-                    "id": block_id,
-                    "name": block_name,
-                    "eligible": eligible,
-                }
-                flat_block_tree.append(new_entry)
-                if block.has_children and not getattr(block, "has_dynamic_children", lambda: False)():
-                    for child_id in block.children:
-                        build_tree(block.runtime.get_block(child_id), ancestors=(ancestors + [new_entry]))
-
-        root_block = self
-        while root_block.parent:
-            root_block = root_block.get_parent()
-        root_block_id = get_block_id(root_block)
-        root_entry = {
-            "depth": 0,
-            "id": root_block_id,
-            "name": "All",
-            "eligible": False,
-        }
-        flat_block_tree.append(root_entry)
-
-        for child_id in root_block.children:
-            child_block = root_block.runtime.get_block(child_id)
-            build_tree(child_block, [root_entry])
-
-        return flat_block_tree
 
     @property
     def download_url_for_last_report(self):

--- a/problem_builder/questionnaire.py
+++ b/problem_builder/questionnaire.py
@@ -235,3 +235,10 @@ class QuestionnaireAbstractBlock(
             format_html = getattr(self.runtime, 'replace_urls', lambda html: html)
             return format_html(self.message)
         return ""
+
+    def student_view_data(self):
+        """
+        Returns a JSON representation of the student_view of this XBlock,
+        retrievable from the Course Block API.
+        """
+        return {'question': self.question}

--- a/problem_builder/templates/html/instructor_tool.html
+++ b/problem_builder/templates/html/instructor_tool.html
@@ -28,14 +28,8 @@
       <div class="data-export-field">
         <label>
           <span>{% trans "Section/Question:" %}</span>
-          <select name="root_block_id">
-            {% for block in block_tree %}
-            <option value="{{ block.id }}"
-                    {% if not block.eligible %} disabled="disabled" {% endif %}>
-              {% for _ in ""|ljust:block.depth %}&nbsp;&nbsp;{% endfor %}
-              {{ block.name }}
-            </option>
-            {% endfor %}
+          <select name="root_block_id" data-course-blocks-api="{{course_blocks_api}}">
+            <option value="{{root_block_id}}">{% trans "All" %}</option>
           </select>
         </label>
       </div>

--- a/problem_builder/tests/unit/test_instructor_tool.py
+++ b/problem_builder/tests/unit/test_instructor_tool.py
@@ -5,7 +5,7 @@ import ddt
 import unittest
 from mock import Mock, patch
 from xblock.field_data import DictFieldData
-from problem_builder.instructor_tool import InstructorToolBlock
+from problem_builder.instructor_tool import InstructorToolBlock, COURSE_BLOCKS_API
 
 
 @ddt.ddt
@@ -31,188 +31,15 @@ class TestInstructorToolBlock(unittest.TestCase):
         return block
 
     def setUp(self):
+        self.course_id = 'course-v1:edX+DemoX+Demo_Course'
         self.runtime_mock = Mock()
         self.runtime_mock.get_block = self._get_block
+        self.runtime_mock.course_id = self.course_id
         scope_ids_mock = Mock()
         scope_ids_mock.usage_id = u'0'
         self.block = InstructorToolBlock(
             self.runtime_mock, field_data=DictFieldData({}), scope_ids=scope_ids_mock
         )
-        self.block.children = [
-            # No attributes: Prefer usage_id
-            {'usage_id': u'1'},
-            # Single attribute: Prefer attribute that's present
-            {'usage_id': u'2', 'preferred_attr': 'question', 'attrs': {'question': 'question'}},
-            {'usage_id': u'3', 'preferred_attr': 'name', 'attrs': {'name': 'name'}},
-            {'usage_id': u'4', 'preferred_attr': 'display_name', 'attrs': {'display_name': 'display_name'}},
-            # Two attributes (question, name): Prefer question
-            {
-                'usage_id': u'5',
-                'preferred_attr':
-                'question', 'attrs': {'question': 'question', 'name': 'name'}
-            },
-            # Two attributes (question, display_name): Prefer question
-            {
-                'usage_id': u'6',
-                'preferred_attr': 'question',
-                'attrs': {'question': 'question', 'display_name': 'display_name'}
-            },
-            # Two attributes (name, display_name): Prefer name
-            {
-                'usage_id': u'7',
-                'preferred_attr': 'name',
-                'attrs': {'name': 'name', 'display_name': 'display_name'}
-            },
-            # All attributes: Prefer question
-            {
-                'usage_id': u'8',
-                'preferred_attr': 'question',
-                'attrs': {'question': 'question', 'name': 'name', 'display_name': 'display_name'}
-            },
-        ]
-
-    def test_build_course_tree_uses_preferred_attrs(self):
-        """
-        Check if `_build_course_tree` method uses preferred block
-        attributes for `id` and `name` of each block.
-
-        Each entry of the block tree returned by `_build_course_tree`
-        is a dictionary that must contain an `id` key and a `name`
-        key.
-
-        - `id` must be set to the ID (usage_id or block_id)
-          of the corresponding block.
-
-        - `name` must be set to the value of one of the following attributes
-           of the corresponding block:
-
-          - question
-          - name (question ID)
-          - display_name (question title)
-          - block ID
-
-          Note that the attributes are listed in order of preference;
-          i.e., if `block.question` has a meaningful value, that value
-          should be used for `name` (irrespective of what the values
-          of the other attributes might be).
-        """
-        block_tree = self.block._build_course_tree()
-
-        def check_block(usage_id, expected_name):
-            # - Does block_tree contain single entry whose `id` matches `usage_id` of block?
-            matching_blocks = [block for block in block_tree if block['id'] == usage_id]
-            self.assertEqual(len(matching_blocks), 1)
-            # - Is `name` of that entry set to `expected_name`?
-            matching_block = matching_blocks[0]
-            self.assertEqual(matching_block['name'], expected_name)
-
-        # Check size of block_tree
-        num_blocks = len(self.block.children) + 1
-        self.assertEqual(len(block_tree), num_blocks)
-
-        # Check block_tree for root entry
-        check_block(usage_id=self.block.scope_ids.usage_id, expected_name='All')
-
-        # Check block_tree for children
-        for child in self.block.children:
-            usage_id = child.get('usage_id')
-            attrs = child.get('attrs', {})
-            if not attrs:
-                expected_name = usage_id
-            else:
-                preferred_attr = child.get('preferred_attr')
-                expected_name = attrs[preferred_attr]
-            check_block(usage_id, expected_name)
-
-    def test_build_course_tree_excludes_choice_blocks(self):
-        """
-        Check if `_build_course_tree` method excludes 'pb-choice' blocks.
-        """
-        # Pretend that all blocks in self.block.children are of type 'pb-choice:
-        self.runtime_mock.id_reader = Mock()
-        self.runtime_mock.id_reader.get_block_type.return_value = 'pb-choice'
-
-        block_tree = self.block._build_course_tree()
-
-        # Check size of block_tree: Should only include root block
-        self.assertEqual(len(block_tree), 1)
-
-    @ddt.data('pb-mcq', 'pb-rating', 'pb-answer')
-    def test_build_course_tree_eligible_blocks(self, block_type):
-        """
-        Check if `_build_course_tree` method correctly marks MCQ, Rating,
-        and Answer blocks as eligible.
-
-        A block is eligible if its type is one of {'pb-mcq', 'pb-rating', 'pb-answer'}.
-        """
-        # Pretend that all blocks in self.block.children are eligible:
-        self.runtime_mock.id_reader = Mock()
-        self.runtime_mock.id_reader.get_block_type.return_value = block_type
-
-        block_tree = self.block._build_course_tree()
-
-        # Check size of block_tree: All blocks should be included
-        num_blocks = len(self.block.children) + 1
-        self.assertEqual(len(block_tree), num_blocks)
-
-        # Check if all blocks are eligible:
-        self.assertTrue(all(block['eligible'] for block in block_tree))
-
-    @ddt.data(
-        'problem-builder',
-        'pb-table',
-        'pb-column',
-        'pb-answer-recap',
-        'pb-mrq',
-        'pb-message',
-        'pb-tip',
-        'pb-dashboard',
-        'pb-data-export',
-        'pb-instructor-tool',
-    )
-    def test_build_course_tree_ineligible_blocks(self, block_type):
-        """
-        Check if `_build_course_tree` method correctly marks blocks that
-        aren't MCQ, Rating, or Answer blocks as ineligible.
-        """
-        # Pretend that none of the blocks in self.block.children are eligible:
-        self.runtime_mock.id_reader = Mock()
-        self.runtime_mock.id_reader.get_block_type.return_value = block_type
-
-        block_tree = self.block._build_course_tree()
-
-        # Check size of block_tree: All blocks should be included (they are not of type 'pb-choice')
-        num_blocks = len(self.block.children) + 1
-        self.assertEqual(len(block_tree), num_blocks)
-
-        # Check if all blocks are ineligible:
-        self.assertTrue(all(not block['eligible'] for block in block_tree))
-
-    def test_build_course_tree_supports_new_style_keys(self):
-        """
-        Check if `_build_course_tree` method correctly handles new-style keys.
-
-        To determine eligibility of a given block,
-        `_build_course_tree` has to obtain the blocks's type. It uses
-        `block.runtime.id_reader.get_block_type` to do this. It first
-        tries to pass `block.scope_ids.def_id` as an argument.
-
-        **If old-style keys are enabled, this will work. If new-style
-        keys are enabled, this will fail with an AttributeError.**
-
-        `_build_course_tree` should not let this error bubble up.
-        Instead, it should catch the error and try again, this time
-        passing `block.scope_ids.usage_id` to the method mentioned
-        above (which will work if new-style keys are enabled).
-        """
-        # Pretend that new-style keys are enabled:
-        self.block.scope_ids.def_id = Mock()
-        self.block.scope_ids.def_id.block_type.side_effect = AttributeError()
-
-        try:
-            self.block._build_course_tree()
-        except AttributeError:
-            self.fail('student_view breaks if new-style keys are enabled.')
 
     def test_student_view_template_args(self):
         """
@@ -224,16 +51,15 @@ class TestInstructorToolBlock(unittest.TestCase):
             'Rating Question': 'RatingBlock',
             'Long Answer': 'AnswerBlock',
         }
-        flat_block_tree = ['block{}'.format(i) for i in range(10)]
-        self.block._build_course_tree = Mock(return_value=flat_block_tree)
 
         with patch('problem_builder.instructor_tool.loader') as patched_loader:
             patched_loader.render_template.return_value = u''
             self.block.student_view()
-            patched_loader.render_template.assert_called_once_with(
-                'templates/html/instructor_tool.html',
-                {'block_choices': block_choices, 'block_tree': flat_block_tree}
-            )
+            patched_loader.render_template.assert_called_once_with('templates/html/instructor_tool.html', {
+                'block_choices': block_choices,
+                'course_blocks_api': COURSE_BLOCKS_API,
+                'root_block_id': self.course_id,
+            })
 
     def test_author_view(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='2.6.1',
+    version='2.6.2',
     description='XBlock - Problem Builder',
     packages=['problem_builder', 'problem_builder.v1'],
     install_requires=[


### PR DESCRIPTION
Moves the logic that populates the Instructor Tool's drop-down list of course blocks out of the server-side and into the client, using the Course Blocks API as the data source.

**Discussions**: In [#119](https://github.com/open-craft/problem-builder/pull/119#discussion_r85763360), @ormsbee raised concerns about performance and maintainability of the old server-side mechanism for traversing the course blocks via the runtime object's parents.

**Sandbox URL**: 

* LMS: http://pr13953.sandbox.opencraft.hosting (persistent databases)
* Studio: http://studio-pr13953.sandbox.opencraft.hosting

**Partner information**: DavidsonX

**Testing instructions**:

1. Ensure your devstack is updated to current `master`.
1. Install the previous version of Problem Builder, [v2.6.1](https://github.com/open-craft/problem-builder/tree/v2.6.1).
1. Create a course, and import [course.99Ob05.tar.gz](https://github.com/open-craft/problem-builder/files/575891/course.99Ob05.tar.gz).
1. Visit the `Features > Instructor Tool` unit, and note the list of course block options available for "Section/Question".
1. Install this branch's version of Problem Builder.
1. Visit the `Features > Instructor Tool` unit, and note that the list of course block options has not changed.

Alternatively, you can compare the sandbox from this PR with the one for v2.6.1, https://github.com/edx/edx-platform/pull/13938.

**Author notes and concerns**:

1. This change removes the python tests related to the course block tree creation, since that logic has been removed from the server-side.  However, we don't currently have any JS/Jasmine tests for this xblock, and so no JS tests have been added to test the new client-side code.

**Reviewers**
- [ ] @itsjeyd 
- [ ] edX reviewer[s] TBD