### PR TITLE
Extend course_id field to 255 characters.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ dependencies:
     - "pip install -r requirements.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt"
-    - "pip uninstall -y xblock-problem-builder && python setup.py sdist && pip install dist/xblock-problem-builder-2.6.2.tar.gz"
+    - "pip uninstall -y xblock-problem-builder && python setup.py sdist && pip install dist/xblock-problem-builder-2.6.3.tar.gz"
     - "pip install -r test_requirements.txt"
     - "mkdir var"
 test:

--- a/problem_builder/migrations/0003_auto_20161116_0730.py
+++ b/problem_builder/migrations/0003_auto_20161116_0730.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('problem_builder', '0002_auto_20160121_1525'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='answer',
+            name='course_id',
+            field=models.CharField(max_length=255, db_index=True),
+        ),
+    ]

--- a/problem_builder/models.py
+++ b/problem_builder/models.py
@@ -39,7 +39,7 @@ class Answer(models.Model):
 
     name = models.CharField(max_length=50, db_index=True)
     student_id = models.CharField(max_length=32, db_index=True)
-    course_id = models.CharField(max_length=50, db_index=True)
+    course_id = models.CharField(max_length=255, db_index=True)
     student_input = models.TextField(blank=True, default='')
     created_on = models.DateTimeField('created on', auto_now_add=True)
     modified_on = models.DateTimeField('modified on', auto_now=True)

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='2.6.2',
+    version='2.6.3',
     description='XBlock - Problem Builder',
     packages=['problem_builder', 'problem_builder.v1'],
     install_requires=[


### PR DESCRIPTION
This patch extends the `course_id` column to 255 characters.

Previous limit of 50 characters was too low, causing 500 errors when adding the 'Long Answer' block to a course with a course key extending 50 characters.

**JIRA ticket**: [TNL-5932](https://openedx.atlassian.net/browse/TNL-5932)

**Partner information**: DavidsonX

**Testing instructions**:

Steps to reproduce:

1. Install problem-builder xblock without this patch (v2.6.2).
1. Create a new course with a long course key in Studio (choose long organization, course number and course run fields, for example: "VeryLongOrganizationName", "VeryLongCourseName", "VeryLongCourseRun2016")
1. Add "problem-builder" to list of advanced modules in advanced settings.
1. Create a new unit and add a 'Problem Builder' block.
1. Add 'Long Answer' block to the problem builder block.
1. Studio will report an error.

Steps to verify the fix:

1. Install this branch of problem builder.
1. Run migrations.
1. Restart Studio.
1. Verify that you can now successfully add 'Long Answer' components to the course that you created above.

**Reviewers**
- [ ] @pomegranited 
- [ ] edX reviewer[s] TBD