### PR TITLE
Introduce Answer.course_key and deprecate course_id.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ dependencies:
     - "pip install -r requirements.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt"
-    - "pip uninstall -y xblock-problem-builder && python setup.py sdist && pip install dist/xblock-problem-builder-2.6.3.tar.gz"
+    - "pip uninstall -y xblock-problem-builder && python setup.py sdist && pip install dist/xblock-problem-builder-2.6.4.tar.gz"
     - "pip install -r test_requirements.txt"
     - "mkdir var"
 test:

--- a/problem_builder/migrations/0003_auto_20161124_0755.py
+++ b/problem_builder/migrations/0003_auto_20161124_0755.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('problem_builder', '0002_auto_20160121_1525'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='answer',
+            name='course_key',
+            field=models.CharField(default=None, max_length=255, null=True, db_index=True),
+        ),
+        migrations.AlterUniqueTogether(
+            name='answer',
+            unique_together=set([('student_id', 'course_key', 'name'), ('student_id', 'course_id', 'name')]),
+        ),
+    ]

--- a/problem_builder/models.py
+++ b/problem_builder/models.py
@@ -35,11 +35,19 @@ class Answer(models.Model):
     """
 
     class Meta:
-        unique_together = (('student_id', 'course_id', 'name'),)
+        unique_together = (
+            ('student_id', 'course_id', 'name'),
+            ('student_id', 'course_key', 'name'),
+        )
 
     name = models.CharField(max_length=50, db_index=True)
     student_id = models.CharField(max_length=32, db_index=True)
+    # course_id is deprecated; it will be removed in next release.
     course_id = models.CharField(max_length=50, db_index=True)
+    # course_key is the new course_id replacement with extended max_length.
+    # We need to allow NULL values during the transition period,
+    # but we will remove the null=True and default=None parameters in next release.
+    course_key = models.CharField(max_length=255, db_index=True, null=True, default=None)
     student_input = models.TextField(blank=True, default='')
     created_on = models.DateTimeField('created on', auto_now_add=True)
     modified_on = models.DateTimeField('modified on', auto_now=True)

--- a/problem_builder/tests/unit/test_answer_mixin.py
+++ b/problem_builder/tests/unit/test_answer_mixin.py
@@ -1,0 +1,78 @@
+"""
+Tests temporary AnswerMixin code that helps migrate course_id column to course_key.
+"""
+import unittest
+from collections import namedtuple
+from django.utils.crypto import get_random_string
+from mock import patch
+
+from problem_builder.answer import AnswerMixin
+from problem_builder.models import Answer
+
+
+class TestAnswerMixin(unittest.TestCase):
+    """ Unit tests for AnswerMixin. """
+
+    FakeRuntime = namedtuple('FakeRuntime', ['course_id', 'anonymous_student_id'])
+
+    def setUp(self):
+        self.course_id = 'course-v1:edX+DemoX+Demo_Course'
+        self.anonymous_student_id = '12345678987654321'
+
+    def make_answer_mixin(self, name=None, course_id=None, student_id=None):
+        if name is None:
+            name = get_random_string()
+        if course_id is None:
+            course_id = self.course_id
+        if student_id is None:
+            student_id = self.anonymous_student_id
+        answer_mixin = AnswerMixin()
+        answer_mixin.name = name
+        answer_mixin.runtime = self.FakeRuntime(course_id, student_id)
+        return answer_mixin
+
+    def test_creates_model_instance(self):
+        name = 'test-model-creation'
+        answer_mixin = self.make_answer_mixin(name=name)
+        model = answer_mixin.get_model_object()
+        self.assertEqual(model.name, name)
+        self.assertEqual(model.student_id, self.anonymous_student_id)
+        self.assertEqual(model.course_id, self.course_id)
+        self.assertEqual(model.course_key, self.course_id)
+        self.assertEqual(Answer.objects.get(pk=model.pk), model)
+
+    def test_finds_instance_by_course_key(self):
+        name = 'test-course-key'
+        existing_model = Answer(
+            name=name,
+            student_id=self.anonymous_student_id,
+            course_key=self.course_id,
+            course_id='ignored'
+        )
+        existing_model.save()
+        answer_mixin = self.make_answer_mixin(name=name)
+        model = answer_mixin.get_model_object()
+        self.assertEqual(model, existing_model)
+
+    def test_finds_instance_by_course_id(self):
+        name = 'test-course-id'
+        existing_model = Answer(
+            name=name,
+            student_id=self.anonymous_student_id,
+            course_id=self.course_id,
+            course_key=None
+        )
+        # Temporarily patch full_clean to allow saving object with blank course_key to the database.
+        with patch.object(Answer, 'full_clean', return_value=None):
+            existing_model.save()
+        answer_mixin = self.make_answer_mixin(name=name)
+        model = answer_mixin.get_model_object()
+        self.assertEqual(model, existing_model)
+        self.assertEqual(model.course_key, self.course_id)
+
+    def test_works_with_long_course_keys(self):
+        course_id = 'course-v1:VeryLongOrganizationName+VeryLongCourseNumber+VeryLongCourseRun'
+        self.assertTrue(len(course_id) > 50)  # precondition check
+        answer_mixin = self.make_answer_mixin(course_id=course_id)
+        model = answer_mixin.get_model_object()
+        self.assertEqual(model.course_key, course_id)

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='2.6.3',
+    version='2.6.4',
     description='XBlock - Problem Builder',
     packages=['problem_builder', 'problem_builder.v1'],
     install_requires=[


### PR DESCRIPTION
This patch introduces a new 255-char `course_key` field to the `Answer` model. The old 50-char `course_id` field is still present, but is deprecated and will be removed in next release.

It removes the previous migration (which was never deployed to production) which extended the existing `course_id` field to 255 characters, which was found to not be the optimal approach on the edx.org production database due to the relevant table's size. We cannot simply extend the existing `course_id` field because we have some large `problem_builder_answer` tables in production and the migration to extend the column would lock the table causing issues in production.

The code is updated so that it uses the new `course_key` column, but falls back to `course_id`.
In next release, a data migration to copy course_id data to `course_key` will be provided and the `course_id` column dropped.

Below is the output of `sqlmigrate` for the new migration:

```
BEGIN;
ALTER TABLE `problem_builder_answer` ADD COLUMN `course_key` varchar(255) NULL;
ALTER TABLE `problem_builder_answer` ADD CONSTRAINT `problem_builder_answer_student_id_2ce682a818c95cbc_uniq` UNIQUE (`student_id`, `course_key`, `name`);
CREATE INDEX `problem_builder_answer_c8235886` ON `problem_builder_answer` (`course_key`);

COMMIT;
```

Next release will add a data migration to copy contents of `course_id` to the new `course_key` column. EdX will fake this migration and copy data in batches instead.
Next release will also drop the deprecated `course_id` column.

See https://github.com/edx/edx-platform/pull/14013#issuecomment-261635454 for more information.

**Environments**:  edx.org and edge.edx.org

**Merge deadline**: ASAP - this is blocking a course on Edge

**JIRA tickets**: [TNL-5932](https://openedx.atlassian.net/browse/TNL-5932)

**Discussions**: See https://github.com/edx/edx-platform/pull/14013 and JIRA ticket.

**Sandbox URL**:

- LMS: http://pr14044.sandbox.opencraft.hosting/
- Studio: http://studio-pr14044.sandbox.opencraft.hosting/

**Partner information**: hosted on edX Edge (Davidson College)

**Testing instructions**:

Check that you can successfully add a Problem Builder "Long Answer" component to a course with a course key that is longer than 50 character and that answers answered on an older version of problem-builder continue to work correctly with this patch.

1. Install problem-builder v2.6.1
1. Create a course with a combined course key less than 50 characters.
1. Add a Problem Builder component, then add the Long Answer component.
1. Answered several questions.
1. Create a course with a combined course key *more* than 50 characters.
1. Add Unit with Problem Builder and a Long Answer element - watched it fail.
1. Installed problem-builder from this PR.
1. Run migrations.
1. Verify that the answers are still present in the first course.
1. Verify that the Long Answer element in the course with the very long course ID is working now, and you can submit answers to it.

**Reviewers**
- [x] @pomegranited