### PR TITLE
YONK-476: fixed review step not showing tip and result icon

### DIFF
--- a/problem_builder/public/js/questionnaire.js
+++ b/problem_builder/public/js/questionnaire.js
@@ -126,7 +126,7 @@ function MCQBlock(runtime, element) {
 
             messageView.clearResult();
 
-            var choiceInputDOM = $('.choice-selector input[value="'+ result.submission +'"]');
+            var choiceInputDOM = $('.choice-selector input[value="'+ result.submission +'"]', element);
             var choiceDOM = choiceInputDOM.closest('.choice');
             var choiceResultDOM = $('.choice-result', choiceDOM);
             var choiceTipsDOM = $('.choice-tips', choiceDOM);


### PR DESCRIPTION
This PR fixes a bug where tip and result icon is not appeared on review step when two MCQ questions in a step build share two same choices.

To reproduce the issue

1.  import [sample course](https://github.com/open-craft/problem-builder/files/616223/2016.nQWXtB.tar.gz)
2.  Enroll in newly imported course and attempt Sport Quiz -> Football Quiz
3.  Select **Baltimore Colts** for first Question and **Atlanta Falcons** for second question
4.  On Review step click **Question 2**. You'll neither be able to see a red cross before **Atlanta Falcons** nor a tip next to it.

@bradenmacdonald can you assign are reviewer to this?

