### PR TITLE
Fix display of MCQ/MRQ choices with long text.

### DIFF
--- a/problem_builder/public/css/questionnaire.css
+++ b/problem_builder/public/css/questionnaire.css
@@ -2,17 +2,21 @@
     display: table;
     position: relative;
     width: 100%;
-    border-spacing: 0 6px;
+    border-spacing: 0 2px;
     padding-top: 10px;
     margin-bottom: 10px;
 }
 
 .mentoring .questionnaire .choice-result {
-    display: inline-block;
+    display: table-cell;
     width: 34px;
     vertical-align: top;
     cursor: pointer;
     float: none;
+}
+
+.mentoring div[data-block-type=pb-mrq] .questionnaire .choice-result {
+    display: inline-block;
 }
 
 .mentoring .questionnaire .choice {
@@ -78,7 +82,12 @@
 }
 
 .mentoring .choices-list .choice-selector {
-    display: inline-block;
+    display: table-cell;
+}
+
+.mentoring .choices-list .choice-label-text {
+    display: table-cell;
+    padding-left: 0.4em;
 }
 
 .mentoring .choice-tips-container,

--- a/problem_builder/public/css/questionnaire.css
+++ b/problem_builder/public/css/questionnaire.css
@@ -88,6 +88,7 @@
 .mentoring .choices-list .choice-label-text {
     display: table-cell;
     padding-left: 0.4em;
+    padding-right: 0.4em;
 }
 
 .mentoring .choice-tips-container,

--- a/problem_builder/public/js/questionnaire.js
+++ b/problem_builder/public/js/questionnaire.js
@@ -221,7 +221,9 @@ function MRQBlock(runtime, element) {
                 display_message(result.message, messageView, options.checkmark);
             }
 
-            $.each(result.choices, function(index, choice) {
+            // If user has never submitted an answer for this MRQ, `result` will be empty.
+            // So we need to fall back on an empty list for `result.choices` to avoid errors in the next step:
+            $.each(result.choices || [], function(index, choice) {
                 var choiceInputDOM = $('.choice input[value='+choice.value+']', element);
                 var choiceDOM = choiceInputDOM.closest('.choice');
                 var choiceResultDOM = $('.choice-result', choiceDOM);

--- a/problem_builder/templates/html/mcqblock.html
+++ b/problem_builder/templates/html/mcqblock.html
@@ -8,15 +8,17 @@
     {% for choice in custom_choices %}
     <div class="choice" aria-live="polite" aria-atomic="true">
       <label class="choice-label"
-        aria-describedby="feedback_{{ self.html_id }} choice_tips_{{ self.html_id }}-{{ forloop.counter }}">
-        <div class="choice-result fa icon-2x" aria-label=""
-          data-label_correct="{% trans "Correct" %}" data-label_incorrect="{% trans "Incorrect" %}"></div>
-        <div class="choice-selector">
+             aria-describedby="feedback_{{ self.html_id }} choice_tips_{{ self.html_id }}-{{ forloop.counter }}">
+        <span class="choice-result fa icon-2x"
+              aria-label=""
+              data-label_correct="{% trans "Correct" %}"
+              data-label_incorrect="{% trans "Incorrect" %}"></span>
+        <span class="choice-selector">
           <input type="radio" name="{{ self.name }}" value="{{ choice.value }}"
             {% if self.student_choice == choice.value and not hide_prev_answer %} checked{% endif %}
           />
-        </div>
-        {{ choice.content|safe }}
+        </span>
+        <span class="choice-label-text">{{ choice.content|safe }}</span>
       </label>
       <div class="choice-tips-container">
         <div class="choice-tips" id="choice_tips_{{ self.html_id }}-{{ forloop.counter }}"></div>

--- a/problem_builder/templates/html/mrqblock.html
+++ b/problem_builder/templates/html/mrqblock.html
@@ -8,17 +8,20 @@
   <div class="choices-list">
     {% for choice in custom_choices %}
     <div class="choice" aria-live="polite" aria-atomic="true">
-      <div class="choice-result fa icon-2x" id="result_{{ self.html_id }}-{{ forloop.counter }}" aria-label=""
-        data-label_correct="{% trans "Correct" %}" data-label_incorrect="{% trans "Incorrect" %}"></div>
+      <div class="choice-result fa icon-2x"
+           id="result_{{ self.html_id }}-{{ forloop.counter }}"
+           aria-label=""
+           data-label_correct="{% trans "Correct" %}"
+           data-label_incorrect="{% trans "Incorrect" %}"></div>
       <label class="choice-label" aria-describedby="feedback_{{ self.html_id }}
                                                     result_{{ self.html_id }}-{{ forloop.counter }}
                                                     choice_tips_{{ self.html_id }}-{{ forloop.counter }}">
-        <div class="choice-selector">
+        <span class="choice-selector">
           <input type="checkbox" name="{{ self.name }}" value="{{ choice.value }}"
              {% if choice.value in self.student_choices and not hide_prev_answer %} checked{% endif %}
           />
-        </div>
-        {{ choice.content|safe }}
+        </span>
+        <span class="choice-label-text">{{ choice.content|safe }}</span>
       </label>
       <div class="choice-tips-container">
         <div class="choice-tips" id="choice_tips_{{ self.html_id }}-{{ forloop.counter }}"></div>

--- a/problem_builder/templates/html/ratingblock.html
+++ b/problem_builder/templates/html/ratingblock.html
@@ -8,17 +8,19 @@
     {% for i in '12345' %}
     <div class="choice" aria-live="polite" aria-atomic="true">
       <label class="choice-label"
-        aria-describedby="feedback_{{ self.html_id }} choice_tips_{{ self.html_id }}-{{ i }}">
-        <div class="choice-result fa icon-2x" aria-label=""
-          data-label_correct="{% trans "Correct" %}" data-label_incorrect="{% trans "Incorrect" %}"></div>
-        <div class="choice-selector">
+             aria-describedby="feedback_{{ self.html_id }} choice_tips_{{ self.html_id }}-{{ i }}">
+        <span class="choice-result fa icon-2x" aria-label=""
+              data-label_correct="{% trans "Correct" %}" data-label_incorrect="{% trans "Incorrect" %}"></span>
+        <span class="choice-selector">
           <input type="radio" name="{{ self.name }}" value="{{i}}"
             {% if self.student_choice == i and not hide_prev_answer %} checked{%else%} data-student-choice='{{self.student_choice}}'{% endif %}
           />
+        </span>
+        <span class="choice-label-text">
           {{i}}
           {% if i == '1' %} - {{ self.low|safe }}{% endif %}
           {% if i == '5' %} - {{ self.high|safe }}{% endif %}
-        </div>
+        </span>
       </label>
       <div class="choice-tips-container">
         <div class="choice-tips" id="choice_tips_{{ self.html_id }}-{{ i }}"></div>
@@ -29,15 +31,15 @@
     {% for choice in custom_choices %}
     <div class="choice" aria-live="polite" aria-atomic="true">
       <label class="choice-label"
-        aria-describedby="feedback_{{ self.html_id }} choice_tips_{{ self.html_id }}-{{ forloop.counter }}">
-        <div class="choice-result fa icon-2x" aria-label=""
-          data-label_correct="{% trans "Correct" %}" data-label_incorrect="{% trans "Incorrect" %}"></div>
-        <div class="choice-selector">
+             aria-describedby="feedback_{{ self.html_id }} choice_tips_{{ self.html_id }}-{{ forloop.counter }}">
+        <span class="choice-result fa icon-2x" aria-label=""
+              data-label_correct="{% trans "Correct" %}" data-label_incorrect="{% trans "Incorrect" %}"></span>
+        <span class="choice-selector">
           <input type="radio" name="{{ self.name }}" value="{{ choice.value }}"
             {% if self.student_choice == choice.value and not hide_prev_answer %} checked{%else%} data-student-choice='{{self.student_choice}}'{% endif %}
           />
-        </div>
-        {{ choice.content|safe }}
+        </span>
+        <span class="choice-label-text">{{ choice.content|safe }}</span>
       </label>
       <div class="choice-tips-container">
         <div class="choice-tips" id="choice_tips_{{ self.html_id }}-{{ forloop.counter }}"></div>


### PR DESCRIPTION
Reported by McKinsey.

cf. [OC-2264](https://tasks.opencraft.com/browse/OC-2264)

**Screenshots** (Apros)

MCQ:

![mcq](https://cloud.githubusercontent.com/assets/961441/22251681/f5962d12-e24b-11e6-86ca-105a684b5f95.png)

MCQ during review (with tip):

![mcq-review-tip](https://cloud.githubusercontent.com/assets/961441/22251704/0f04b2c8-e24c-11e6-9fbb-3e93361a9b1f.png)

Rating question:

![rating](https://cloud.githubusercontent.com/assets/961441/22251715/1560c72e-e24c-11e6-8929-73f0b5e286ca.png)

Rating question during review (without tip):

![rating-review](https://cloud.githubusercontent.com/assets/961441/22251725/1e660172-e24c-11e6-8302-67a75d11f6fe.png)

MRQ:

![mrq](https://cloud.githubusercontent.com/assets/961441/22251737/26d20040-e24c-11e6-86e8-13b6b84c2eb7.png)

MRQ during review (without tip):

![mrq-review](https://cloud.githubusercontent.com/assets/961441/22251746/3101fb6a-e24c-11e6-9c2c-96de5c53cac8.png)

**Test instructions**

1. Add a Step Builder block to a unit, setting "Max. attempts allowed" to a non-zero value, and "Extended Feedback" to True.

2. Add a Mentoring Step block and a Review Step block to the Step Builder block.

3. Add an MCQ, Rating, and MRQ to the Mentoring Step block, setting the text of some choices to a long string.

4. Add tips for individual choices to the MCQ.

5. Add a Score Summary block to the Review Step block.

6. Publish the unit and navigate to it in the LMS/Apros. Observe that alignment of choice texts matches screenshots.

7. Answer the questions, submit, and review grade until you have no attempts left. Use links to individual questions to review answers. Observe that alignment of choice texts matches screenshots.

**Reviewers**

- [ ] @mtyaka