### PR TITLE
Do not show completion checkmark when hide_feedback is enabled

### DIFF
--- a/problem_builder/public/js/completion.js
+++ b/problem_builder/public/js/completion.js
@@ -16,10 +16,12 @@ function CompletionBlock(runtime, element) {
             return $completion.is(':checked');
         },
 
-        handleSubmit: function(result) {
+        handleSubmit: function(result, options) {
             if (typeof result.submission !== 'undefined') {
                 this.updateCompletion(result);
-                $('.submit-result', element).css('visibility', 'visible');
+                if (!options.hide_results) {
+                    $('.submit-result', element).css('visibility', 'visible');
+                }
             }
         },
 

--- a/problem_builder/tests/integration/xml_templates/feedback_persistence.xml
+++ b/problem_builder/tests/integration/xml_templates/feedback_persistence.xml
@@ -32,6 +32,8 @@
             <pb-tip values='["notwant"]'>Your loss!</pb-tip>
         </pb-rating>
 
+        <pb-completion name="completion_1" question="Did you attend the meeting?" answer="Yes, I did." />
+
         <pb-message type="completed">All Good</pb-message>
         <pb-message type="incomplete">Not done yet</pb-message>
     </problem-builder>


### PR DESCRIPTION
This makes the Completion block consistent with the Answer block.

When 'pb_hide_feedback_if_attempts_remain' is set to True in
XBLOCK_SETTINGS, once the user submits an answer to an Answer (freeform
long answer), the green checkmark is not visible after refreshing the
page, even though the given answer/text is still visible.

This commit makes Completion blocks consistent with that behaviour.

**JIRA ticket**: https://edx-wiki.atlassian.net/browse/MCKIN-4707

**Reviewers**:

- [x] @smarnach 