### PR TITLE
Override layout of choice label in Apros theme

### DIFF
--- a/problem_builder/public/themes/apros.css
+++ b/problem_builder/public/themes/apros.css
@@ -3,6 +3,10 @@
     box-sizing: content-box;  /* Avoid a global reset to border-box found on Apros */
 }
 
+.mentoring .questionnaire .choice-label {
+    width: 100%
+}
+
 .themed-xblock.mentoring .choices-list .choice-selector {
     padding: 4px 3px 0 3px;
     font-size: 16px;


### PR DESCRIPTION
... to incorporate feedback from QA team (cf. https://github.com/open-craft/problem-builder/pull/139#issuecomment-277910917).

Follows up on #139.

**Screenshots: Apros**

Problem Builder:

![problem-builder-apros](https://cloud.githubusercontent.com/assets/961441/22781191/ac5676de-eec1-11e6-9be2-59b9a8d05fb4.png)

Step Builder:

![step-builder-apros](https://cloud.githubusercontent.com/assets/961441/22781241/eaaab620-eec1-11e6-885c-9d099153d1f1.png)

**Screenshots: LMS**

Problem Builder:

![problem-builder-lms](https://cloud.githubusercontent.com/assets/961441/22781580/6ee1c55e-eec3-11e6-9033-541a103ad50a.png)

Step Builder:

![step-builder-lms](https://cloud.githubusercontent.com/assets/961441/22781617/920e2a54-eec3-11e6-9f40-deb345ab76c6.png)

**Test instructions**

1. Make sure you're using the Apros theme. In `lms.env.json`:

    ```json
    "XBLOCK_SETTINGS": {
        "mentoring": {
            "theme": {
                "package": "problem_builder",
                "locations": ["public/themes/apros.css"]
            },
    ```

2. Add MCQs and MRQs with long choice texts to a Problem Builder block.

3. Access Problem Builder block in Apros. Observe that layout of choices matches screenshot above.

4. Repeat previous steps for a Step Builder block.

5. Switch to LMS theme:

    ```json
    "XBLOCK_SETTINGS": {
        "mentoring": {
            "theme": {
                "package": "problem_builder",
                "locations": ["public/themes/lms.css"]
            },
    ```

6. Access Problem Builder and Step Builder blocks in the LMS. Observe that layout of choices matches screenshots above.

**Notes**

Choice tips will partially cover long choice texts when using the Apros theme. This is not a regression as far as McKinsey is concerned: When switching back to 484131cf5df949896bf31d0653a61b57be89e494 (parent of merge commit from #125), we get the same behavior. Also, PRs following #125 did not introduce further changes to the layout of choice texts and choice tips.

**Reviewers**

- [x] @mtyaka 