### PR TITLE
use correct module imports to avoid conflicting models error while arting celery workers

### DIFF
--- a/problem_builder/instructor_tool.py
+++ b/problem_builder/instructor_tool.py
@@ -159,7 +159,7 @@ class InstructorToolBlock(XBlock):
         # Unfortunately this is a bit inefficient due to the ReportStore API
         if not self.last_export_result or self.last_export_result['error'] is not None:
             return None
-        from lms.djangoapps.instructor_task.models import ReportStore
+        from instructor_task.models import ReportStore
         report_store = ReportStore.from_config(config_name='GRADES_DOWNLOAD')
         course_key = getattr(self.scope_ids.usage_id, 'course_key', None)
         return dict(report_store.links_for(course_key)).get(self.last_export_result['report_filename'])

--- a/problem_builder/tasks.py
+++ b/problem_builder/tasks.py
@@ -5,7 +5,7 @@ import time
 
 from celery.task import task
 from celery.utils.log import get_task_logger
-from lms.djangoapps.instructor_task.models import ReportStore
+from instructor_task.models import ReportStore
 from opaque_keys.edx.keys import CourseKey
 from student.models import user_by_anonymous_id
 from xmodule.modulestore.django import modulestore

--- a/problem_builder/tests/integration/test_instructor_tool.py
+++ b/problem_builder/tests/integration/test_instructor_tool.py
@@ -62,10 +62,8 @@ class InstructorToolTest(SeleniumXBlockTest):
 
     @patch.dict('sys.modules', {
         'problem_builder.tasks': MockTasksModule(successful=True),
-        'lms': True,
-        'lms.djangoapps': True,
-        'lms.djangoapps.instructor_task': True,
-        'lms.djangoapps.instructor_task.models': MockInstructorTaskModelsModule(),
+        'instructor_task': True,
+        'instructor_task.models': MockInstructorTaskModelsModule(),
     })
     @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
     def test_export_field_container_width(self):
@@ -81,10 +79,8 @@ class InstructorToolTest(SeleniumXBlockTest):
 
     @patch.dict('sys.modules', {
         'problem_builder.tasks': MockTasksModule(successful=True),
-        'lms': True,
-        'lms.djangoapps': True,
-        'lms.djangoapps.instructor_task': True,
-        'lms.djangoapps.instructor_task.models': MockInstructorTaskModelsModule(),
+        'instructor_task': True,
+        'instructor_task.models': MockInstructorTaskModelsModule(),
     })
     @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
     def test_root_block_select_width(self):
@@ -100,10 +96,8 @@ class InstructorToolTest(SeleniumXBlockTest):
 
     @patch.dict('sys.modules', {
         'problem_builder.tasks': MockTasksModule(successful=True),
-        'lms': True,
-        'lms.djangoapps': True,
-        'lms.djangoapps.instructor_task': True,
-        'lms.djangoapps.instructor_task.models': MockInstructorTaskModelsModule(),
+        'instructor_task': True,
+        'instructor_task.models': MockInstructorTaskModelsModule(),
     })
     @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
     def test_data_export_delete(self):
@@ -132,10 +126,8 @@ class InstructorToolTest(SeleniumXBlockTest):
 
     @patch.dict('sys.modules', {
         'problem_builder.tasks': MockTasksModule(successful=True),
-        'lms': True,
-        'lms.djangoapps': True,
-        'lms.djangoapps.instructor_task': True,
-        'lms.djangoapps.instructor_task.models': MockInstructorTaskModelsModule(),
+        'instructor_task': True,
+        'instructor_task.models': MockInstructorTaskModelsModule(),
     })
     @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
     def test_data_export_success(self):
@@ -172,10 +164,8 @@ class InstructorToolTest(SeleniumXBlockTest):
 
     @patch.dict('sys.modules', {
         'problem_builder.tasks': MockTasksModule(successful=False),
-        'lms': True,
-        'lms.djangoapps': True,
-        'lms.djangoapps.instructor_task': True,
-        'lms.djangoapps.instructor_task.models': MockInstructorTaskModelsModule(),
+        'instructor_task': True,
+        'instructor_task.models': MockInstructorTaskModelsModule(),
     })
     @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
     def test_data_export_error(self):
@@ -206,10 +196,8 @@ class InstructorToolTest(SeleniumXBlockTest):
 
     @patch.dict('sys.modules', {
         'problem_builder.tasks': MockTasksModule(successful=True),
-        'lms': True,
-        'lms.djangoapps': True,
-        'lms.djangoapps.instructor_task': True,
-        'lms.djangoapps.instructor_task.models': MockInstructorTaskModelsModule(),
+        'instructor_task': True,
+        'instructor_task.models': MockInstructorTaskModelsModule(),
     })
     @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
     def test_pagination_no_results(self):
@@ -242,10 +230,8 @@ class InstructorToolTest(SeleniumXBlockTest):
                 'Test section', 'Test subsection', 'Test unit',
                 'Test type', 'Test question', 'Test answer', 'Test username'
             ]]),
-        'lms': True,
-        'lms.djangoapps': True,
-        'lms.djangoapps.instructor_task': True,
-        'lms.djangoapps.instructor_task.models': MockInstructorTaskModelsModule(),
+        'instructor_task': True,
+        'instructor_task.models': MockInstructorTaskModelsModule(),
     })
     @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
     def test_pagination_single_result(self):
@@ -284,10 +270,8 @@ class InstructorToolTest(SeleniumXBlockTest):
                 'Test section', 'Test subsection', 'Test unit',
                 'Test type', 'Test question', 'Test answer', 'Test username'
             ] for _ in range(PAGE_SIZE*3)]),
-        'lms': True,
-        'lms.djangoapps': True,
-        'lms.djangoapps.instructor_task': True,
-        'lms.djangoapps.instructor_task.models': MockInstructorTaskModelsModule(),
+        'instructor_task': True,
+        'instructor_task.models': MockInstructorTaskModelsModule(),
     })
     @patch.object(InstructorToolBlock, 'user_is_staff', Mock(return_value=True))
     def test_pagination_multiple_results(self):


### PR DESCRIPTION
Celery workers were not able to run due to conflicting models imports. This PR fixes the issue.

Here is the error trace
```
Traceback (most recent call last):
  File "./manage.py", line 116, in <module>
    execute_from_command_line([sys.argv[0]] + django_args)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 346, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/djcelery/management/commands/celery.py", line 23, in run_from_argv
    ['{0[0]} {0[1]}'.format(argv)] + argv[2:],
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/bin/celery.py", line 769, in execute_from_commandline
    super(CeleryCommand, self).execute_from_commandline(argv)))
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/bin/base.py", line 311, in execute_from_commandline
    return self.handle_argv(self.prog_name, argv[1:])
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/bin/celery.py", line 761, in handle_argv
    return self.execute(command, argv)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/bin/celery.py", line 693, in execute
    ).run_from_argv(self.prog_name, argv[1:], command=argv[0])
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/bin/worker.py", line 179, in run_from_argv
    return self(*args, **options)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/bin/base.py", line 274, in __call__
    ret = self.run(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/bin/worker.py", line 212, in run
    state_db=self.node_format(state_db, hostname), **kwargs
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/worker/__init__.py", line 95, in __init__
    self.app.loader.init_worker()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/loaders/base.py", line 128, in init_worker
    self.import_default_modules()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/loaders/base.py", line 116, in import_default_modules
    signals.import_modules.send(sender=self.app)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/utils/dispatch/signal.py", line 166, in send
    response = receiver(signal=self, sender=sender, **named)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/amqp/utils.py", line 42, in __call__
    self.set_error_state(exc)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/amqp/utils.py", line 39, in __call__
    **dict(self.kwargs, **kwargs) if self.kwargs else kwargs
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/app/base.py", line 329, in _autodiscover_tasks
    self.loader.autodiscover_tasks(packages, related_name)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/loaders/base.py", line 251, in autodiscover_tasks
    related_name) if mod)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/loaders/base.py", line 272, in autodiscover_tasks
    return [find_related_module(pkg, related_name) for pkg in packages]
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/loaders/base.py", line 298, in find_related_module
    return importlib.import_module('{0}.{1}'.format(package, related_name))
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/edx/app/edxapp/venvs/edxapp/src/problem-builder/problem_builder/tasks.py", line 8, in <module>
    from lms.djangoapps.instructor_task.models import ReportStore
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor_task/models.py", line 35, in <module>
    class InstructorTask(models.Model):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/base.py", line 309, in __new__
    new_class._meta.apps.register_model(new_class._meta.app_label, new_class)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/apps/registry.py", line 221, in register_model
    (model_name, app_label, app_models[model_name], model))
RuntimeError: Conflicting 'instructortask' models in application 'instructor_task': <class 'instructor_task.models.InstructorTask'> and <class 'lms.djangoapps.instructor_task.models.InstructorTask'>.
```

@pomegranited would you please review and merge?
@bradenmacdonald FYI.