### PR TITLE
Add 'name' attribute to AnswerBlock's student_view_data.

### DIFF
--- a/problem_builder/answer.py
+++ b/problem_builder/answer.py
@@ -266,7 +266,10 @@ class AnswerBlock(SubmittingXBlockMixin, AnswerMixin, QuestionMixin, StudioEdita
         Returns a JSON representation of the student_view of this XBlock,
         retrievable from the Course Block API.
         """
-        return {'question': self.question}
+        return {
+            'question': self.question,
+            'name': self.name,
+        }
 
 
 @XBlock.needs("i18n")


### PR DESCRIPTION
It will be useful to be able to get the names of all answer blocks in a course via the Course API.

See http://edx.readthedocs.io/projects/edx-platform-api/en/latest/courses/index.html for information on how Course API and `student_view_data` method work together.

**Testing**:

1. Install this branch into your edx-platform virtual environment.
1. Add a problem builder block with a freeform answer child to a course.
1. Verify that you can see the answer block's name attribute in the output of the Course API if you specify `fields=student_view_data` and `student_view_data=pb-answer` parameters. The full URL should look like this: http://my.edx.local/api/courses/v1/blocks/?course_id=my/course/key&all_blocks=true&depth=all&fields=student_view_data&student_view_data=pb-answer

**Reviewers**:

- [ ] @bdero 