### PR TITLE
Add API for native mobile Problem Builder + MCQ view to Problem Builder

### DIFF
--- a/problem_builder/mcq.py
+++ b/problem_builder/mcq.py
@@ -167,6 +167,27 @@ class MCQBlock(SubmittingXBlockMixin, QuestionnaireAbstractBlock):
                 self._(u"A choice value listed as correct does not exist: {choice}").format(choice=choice_name(val))
             )
 
+    def student_view_data(self):
+        """
+        Returns a JSON representation of the student_view of this XBlock,
+        retrievable from the Course Block API.
+        """
+        return {
+            'id': self.name,
+            'type': self.CATEGORY,
+            'question': self.question,
+            'message': self.message,
+            'choices': [
+                {'value': choice['value'], 'content': choice['display_name']}
+                for choice in self.human_readable_choices
+            ],
+            'weight': self.weight,
+            'tips': [
+                {'content': tip.content, 'for_choices': tip.values}
+                for tip in self.get_tips()
+            ],
+        }
+
 
 class RatingBlock(MCQBlock):
     """

--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -905,6 +905,31 @@ class MentoringBlock(BaseMentoringBlock, StudioContainerWithNestedXBlocksMixin, 
         """
         return loader.load_scenarios_from_path('templates/xml')
 
+    def student_view_data(self):
+        """
+        Returns a JSON representation of the student_view of this XBlock,
+        retrievable from the Course Block API.
+        """
+        components = []
+        for child_id in self.children:
+            block = self.runtime.get_block(child_id)
+            if hasattr(block, 'student_view_data'):
+                components.append(block.student_view_data())
+        return {
+            'max_attempts': self.max_attempts,
+            'extended_feedback': self.extended_feedback,
+            'feedback_label': self.feedback_label,
+            'components': components,
+            'messages': {
+                message_type: self.get_message_content(message_type)
+                for message_type in (
+                        'completed',
+                        'incomplete',
+                        'max_attempts_reached',
+                )
+            }
+        }
+
 
 class MentoringWithExplicitStepsBlock(BaseMentoringBlock, StudioContainerWithNestedXBlocksMixin):
     """

--- a/problem_builder/tests/unit/test_problem_builder.py
+++ b/problem_builder/tests/unit/test_problem_builder.py
@@ -109,6 +109,42 @@ class TestMentoringBlock(BlockWithChildrenTestMixin, unittest.TestCase):
             (['pb-message'] if block.is_assessment else [])  # Message type: "on-assessment-review"
         )
 
+    def test_student_view_data(self):
+        def get_mock_components():
+            child_a = Mock(spec=['student_view_data'])
+            child_a.block_id = 'child_a'
+            child_a.student_view_data.return_value = 'child_a_json'
+            child_b = Mock(spec=[])
+            child_b.block_id = 'child_b'
+            return [child_a, child_b]
+        shared_data = {
+            'max_attempts': 3,
+            'extended_feedback': True,
+            'feedback_label': 'Feedback label',
+        }
+        children = get_mock_components()
+        children_by_id = {child.block_id: child for child in children}
+        block_data = {'children': children}
+        block_data.update(shared_data)
+        block = MentoringBlock(Mock(), DictFieldData(block_data), Mock())
+        block.runtime = Mock(
+            get_block=lambda block: children_by_id[block.block_id],
+            load_block_type=lambda block: Mock,
+            id_reader=Mock(get_definition_id=lambda block: block, get_block_type=lambda block: block),
+        )
+        expected = {
+            'components': [
+                'child_a_json',
+            ],
+            'messages': {
+                'completed': None,
+                'incomplete': None,
+                'max_attempts_reached': None,
+            }
+        }
+        expected.update(shared_data)
+        self.assertEqual(block.student_view_data(), expected)
+
 
 @ddt.ddt
 class TestMentoringBlockTheming(unittest.TestCase):


### PR DESCRIPTION
This PR adds `student_view_data` methods to the Problem Builder and MCQ blocks so their data can be exported as JSON and queried through the Courses API.

**Testing instructions**
1. Install this branch into your edx-platform virtual environment.
2. In Studio, as `staff`, add a Problem Builder block to the demo course and set the following attributes:
- Max. attempts allowed
- Feedback Header
- extended_feedback
3. Check the ID of the block in the message:
`url_name for linking to this mentoring question set: ...`
4. Add a Multiple Choice Question to the PB Block setting the following attributes:
- Question
- Weight
-  Message
5. Add a few choices to the Multiple Choice Question, setting tips for some of them.
6. Add one of each type of message to the PB Block (Complete, Incomplete, Max # Attempts) 
7. In the LMS, as `staff`, query the Courses API for the block using the ID of step 3 (replace BLOCK_ID_GOES_HERE in the following URL):

http://localhost:8000/api/courses/v1/blocks/block-v1:edX+DemoX+Demo_Course+type@problem-builder+block@BLOCK_ID_GOES_HERE?all_blocks=true&depth=all&requested_fields=student_view_data

8. In the result mapping look for the `blocks` key. Find the `problem-builder+block` and `pb-mcq+block` 
 blocks and verify that the values in their `student_view_data` mappings match the attributes and messages you set.