### PR TITLE
Enable mobile support

### DIFF
--- a/problem_builder/dashboard.py
+++ b/problem_builder/dashboard.py
@@ -382,6 +382,7 @@ class DashboardBlock(StudioEditableXBlockMixin, ExportMixin, XBlock):
             if child_isinstance(mentoring_block, child_id, MCQBlock):
                 yield child_id
 
+    @XBlock.supports("multi_device")  # Mark as mobile-friendly
     def student_view(self, context=None):  # pylint: disable=unused-argument
         """
         Standard view of this XBlock.

--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -439,6 +439,7 @@ class MentoringBlock(BaseMentoringBlock, StudioContainerWithNestedXBlocksMixin, 
 
         return Score(score, int(round(score * 100)), correct, incorrect, partially_correct)
 
+    @XBlock.supports("multi_device")  # Mark as mobile-friendly
     def student_view(self, context):
         from .questionnaire import QuestionnaireAbstractBlock  # Import here to avoid circular dependency
 
@@ -1068,6 +1069,7 @@ class MentoringWithExplicitStepsBlock(BaseMentoringBlock, StudioContainerWithNes
     def show_extended_feedback(self):
         return self.extended_feedback and self.max_attempts_reached
 
+    @XBlock.supports("multi_device")  # Mark as mobile-friendly
     def student_view(self, context):
         fragment = Fragment()
         children_contents = []


### PR DESCRIPTION
Since the block is already mostly usable on mobile, this PR will enable mobile views. Over time we will work to improve the responsiveness of each webview version.

Testing notes: This was already tested by the McKA QA team on MCKIN-5241 since this branch was deployed to the QA server for a while. See that ticket for details. To test manually, install this on devstack then build the edX iOS or Android app and confirm that problem builder is usable on mobile.