### PR TITLE
[OC-2856] Fixed deprecation warnings for the Answer and Share models

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ dependencies:
     - "pip install -r requirements.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt"
-    - "pip uninstall -y xblock-problem-builder && python setup.py sdist && pip install dist/xblock-problem-builder-2.6.9.tar.gz"
+    - "pip uninstall -y xblock-problem-builder && python setup.py sdist && pip install dist/xblock-problem-builder-2.6.10.tar.gz"
     - "pip install -r test_requirements.txt"
     - "mkdir var"
 test:

--- a/problem_builder/models.py
+++ b/problem_builder/models.py
@@ -35,6 +35,9 @@ class Answer(models.Model):
     """
 
     class Meta:
+        # Since problem_builder isn't added to INSTALLED_APPS until it's imported,
+        # specify the app_label here.
+        app_label = 'problem_builder'
         unique_together = (
             ('student_id', 'course_id', 'name'),
             ('student_id', 'course_key', 'name'),
@@ -69,4 +72,7 @@ class Share(models.Model):
     notified = models.BooleanField(default=False, db_index=True)
 
     class Meta(object):
+        # Since problem_builder isn't added to INSTALLED_APPS until it's imported,
+        # specify the app_label here.
+        app_label = 'problem_builder'
         unique_together = (('shared_by', 'shared_with', 'block_id'),)

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='2.6.9',
+    version='2.6.10',
     description='XBlock - Problem Builder',
     packages=['problem_builder', 'problem_builder.v1'],
     install_requires=[


### PR DESCRIPTION
This PR simply adds `app_label`s to the problem-builder Answer and Share models (and silences Django deprecation warnings).

**JIRA tickets**: Implements [OC-2856](https://tasks.opencraft.com/browse/OC-2856), [PLAT-1644](https://openedx.atlassian.net/browse/PLAT-1644).

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Deployment targets**: edx.org and edge.edx.org

**Merge deadline**: ASAP

**Testing instructions**:

1. Ensure that the [problem-builder](https://github.com/open-craft/problem-builder) XBlock is installed and running on Studio
2. Check console output and check for absence of the following deprecation warnings:

```
2017-08-04 04:28:57,685 WARNING 23527 [py.warnings] base.py:116 - /edx/src/problem-builder/problem_builder/models.py:59: RemovedInDjango19Warning: Model class problem_builder.models.Share doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
```

**Author notes and concerns**:
1. This is my first PR for Opencraft. Please be blunt about anything that I've missed.

**Reviewers**
- [x] @pomegranited
- [x] @bmedx