### PR TITLE
Add docs about API methods which can be used form native apps

### DIFF
--- a/doc/Native APIs.md
+++ b/doc/Native APIs.md
@@ -335,6 +335,10 @@ Multiple Response Question (`pb-mrq`)
 - `question`: (string) The content of the question.
 - `message`: (string) General feedback provided when submitting.
 - `hide_results`: (boolean) `true` if results should be hidden.
+- `choices`: (array) A list of objects providing info about available
+  choices. See below for more info.
+- `tips`: (array) A list of objects providing info about tips defined for the
+  problem. See below for more info.
 
 ### `student_view_user_state`
 

--- a/doc/Native APIs.md
+++ b/doc/Native APIs.md
@@ -5,10 +5,19 @@ This documents the APIs that can be used to implement native wrappers. There are
 three types of APIs:
 
 - `student_view_data`: Exposes block settings and content as JSON data. Can be
-  retrieved via the edX Course Blocks API. Does not include user-specific data
-  (i.e. items derived from `Scope.user_state` fields).
-- `student_view_user_state`: XBlock handler which returns user state data in
-  JSON format.
+  retrieved via the edX
+  [Course Blocks API](http://edx.readthedocs.io/projects/edx-platform-api/en/latest/courses/blocks.html),
+  e.g.,
+  ```
+  GET https://<lms_server_url>/api/courses/v1/blocks/?course_id=<course_id>&username=<username>&depth=all&requested_fields=student_view_data&student_view_data=<xblock_types>
+  ```
+  Does not include user-specific data, which is available from `student_view_user_state`.
+- `student_view_user_state`: XBlock handler which returns the currently logged
+  in user's state data in JSON format (e.g. items derived from `Scope.user_state`
+  fields).
+  ```
+  GET https://<lms_server_url>/courses/<course_id>/xblock/<xblock_id>/handler/student_view_user_state
+  ```
 - Custom XBlock handlers used for submitting user input and recording user actions.
 
 Problem Builder (`problem-builder`)
@@ -16,45 +25,46 @@ Problem Builder (`problem-builder`)
 
 ### `student_view_data`
 
-- `max_attempts`: Max number of allowed attempts (integer).
-- `extended_feedback`: `true` if extended feedback is enabled for this block
-  (boolean).
-- `feedback_label`: Feedback message header (string).
-- `messages`: A dict with three string entries: `completed`, `incomplete`, and
-  `max_attempts_reached`. See below for info on each (object).
-- `components`: A list of `student_view_data` output of all immediate child
-  components which implement `student_view_data`. Child components which don't
-  implement `student_view_data` are omitted from the list (array).
+- `max_attempts`: (integer) Max number of allowed attempts.
+- `extended_feedback`: (boolean) `true` if extended feedback is enabled for this
+  block.
+- `feedback_label`: (string) Feedback message header.
+- `messages`: (object) A dict with three string entries: `completed`,
+  `incomplete`, and `max_attempts_reached`. See below for info on each.
+- `components`: (array) A list of `student_view_data` output of all immediate
+  child components which implement `student_view_data`. Child components which
+  don't implement `student_view_data` are omitted from the list.
 
 #### `messages`
 
-These messages are displayed as feedback, depending on the state of the block.
+These messages are displayed as feedback, depending on the state of the
+block. Any of these may be `null`.
 
-- `completed`: Message to be shown if the user successfully completes the
-  problem. May contain HTML (string).
-- `incomplete`: Message to be shown if the user did not successfully complete
-  the problem, but still has available attempts left. May contain HTML (string).
-- `max_attempts_reached`: Message to be shown if the user did not complete the
-  problem and has no available attempts left.
+- `completed`: (string) Message to be shown if the user successfully completes
+  the problem. May contain HTML.
+- `incomplete`: (string) Message to be shown if the user did not successfully
+  complete the problem, but still has available attempts left. May contain HTML.
+- `max_attempts_reached`: (string) Message to be shown if the user did not
+  complete the problem and has no available attempts left.
 
 ### `student_view_user_state`
 
-- `num_attempts`: Number of attempts used so far (integer).
-- `completed`: `true` if the user successfully completed the problem at least
-  once (boolean).
-- `student_results`: A list of user submitted answers with metadata for each
-  child component. See below for more info (array).
-- `components`: A dict of `student_view_user_state` output of all immediate
-  child components which implement `student_view_user_state`. Dict keys are
-  component IDs and the value corresponding to each key is the output of
-  `student_view_user_state`(object). Child components which don't implement
-  `student_view_user_state` are not included in the dict.
+- `num_attempts`: (integer) Number of attempts used so far.
+- `completed`: (boolean) `true` if the user successfully completed the problem at least once.
+- `student_results`: (array) A list of user submitted answers with metadata for
+  each child component. See below for more info.
+- `components`: (object) Contains the `student_view_user_state` output of all
+  immediate child components which implement `student_view_user_state`. Each key
+  is a component ID (string), and the value is the component's
+  `student_view_user_state` (object). Child components which don't implement
+  student_view_user_state are not included in the dict.
 
 #### `student_results`
 
 The `student_results` field is an array of two-element arrays. Each nested array
-has the form of `[component_name, data]`. Only components which the student
-already submitted are present in the array. The structure of the `data` object
+has the form of `[component_name, data]`. If the user has not made any
+submissions to particular component, then the element corresponding to that
+component may be omitted from the array. The structure of the `data` object
 depends on the type of the child component and is described separately for each
 type of child component below.
 
@@ -67,42 +77,49 @@ The `submit` XBlock JSON handler is used for submitting student input. The
 depend on the component type and are described separately for each type of child
 component below.
 
+Example URL:
+
+```
+POST https://<lms_server_url>/courses/<course_id>/xblock/<xblock_id>/handler/submit
+```
+
 Returns a JSON object which contains these fields:
 
-- `results`: Same as `student_results` described under
+- `results`: (array) Same as `student_results` described under
   `student_view_user_state` above.
-- `completed`: Same as `completed` described under `student_view_user_state`
-  above.
-- `message`: One of the `completed`, `incomplete`, or `max_attempts_reached`
-  feedback messages described under `messages` above. Can be `null` if no
-  messages has been defined. May contain HTML (string).
-- `max_attempts`: Same as `max_attempts` under `student_view_data`.
-- `num_attempts`: Same as `num_attempts` under `student_view_user_state`.
-
+- `completed`: (boolean) Same as `completed` described under
+  `student_view_user_state` above.
+- `message`: (string) One of the `completed`, `incomplete`, or
+  `max_attempts_reached` feedback messages described under `messages` above. Can
+  be `null` if no messages has been defined. May contain HTML.
+- `max_attempts`: (integer) Same as `max_attempts` under `student_view_data`.
+- `num_attempts`: (integer) Same as `num_attempts` under
+  `student_view_user_state`.
 
 Step Builder (`step-builder`)
 -----------------------------
 
 ### `student_view_data`
 
-- `title`: The display name of the component (string).
-- `show_title`: `true` if the title should be displayed (boolean).
-- `weight`: The weight of the problem (float).
-- `extended_feedback`: `true` if extended feedback is enabled for this block
-  (boolean).
-- `max_attempts`: Max number of allowed attempts (integer).
-- `components`: A list of `student_view_data` output of all immediate child
-  components which implement `student_view_data`. For `step-builder`, immediate
-  children are typically `sb-step` and `sb-review-step` type components. Child
-  components which don't implement `student_view_data` are omitted from the list
-  (array).
+- `title`: (string) The display name of the component.
+- `show_title`: (boolean) `true` if the title should be displayed.
+- `weight`: (float) The weight of the problem.
+- `extended_feedback`: (boolean) `true` if extended feedback is enabled for this
+  block.
+- `max_attempts`: (integer) Max number of allowed attempts.
+- `components`: (array) A list of `student_view_data` output of all immediate
+  child components which implement `student_view_data`. For `step-builder`,
+  immediate children are typically `sb-step` and `sb-review-step` type
+  components. Child components which don't implement `student_view_data` are
+  omitted from the list.
 
 ### `student_view_user_state`
 
-Same as Problem Builder above, but also contains these additional fields:
+Same as [Problem Builder above](#problem-builder-problem-builder), but also
+contains these additional fields:
 
-- `active_step`: The index of the step which is currently active. Starts at zero
-  (integer).
+- `active_step`: (integer) The index of the step which is currently
+  active. Starts at zero.
 
 ### Custom Handlers
 
@@ -116,6 +133,12 @@ component below.
 In addition to child component names, the `POST` data should also include the
 `active_step` field. The value should be the index of the current step.
 
+Example URL:
+
+```
+POST https://<lms_server_url>/courses/<course_id>/xblock/<xblock_id>/handler/submit --data '{"bf9c37a":[{"name":"input","value":"Freeform answer"}],"71f85d0d3e7dabfc1a8cfecf72dce4284f18b13a":"3","71c526b60ec97364214ac70860def69914de84e7":["000bc8e","da9691e"],"477847c4f3540f37b8b3815430a74632a352064d":0.59,"b66a6115af051939c5ce92fb5ff739ccf704d1e9":false}'
+```
+
 #### `try_again`
 
 The `try_again` XBlock JSON handler can be used when the student reaches the
@@ -124,38 +147,44 @@ all of its children.
 
 Returns a JSON object containing the new value of `active_step`.
 
+Example URL:
+
+```
+POST https://<lms_server_url>/courses/<course_id>/xblock/<xblock_id>/handler/try_again
+```
+
 Mentoring Step (`sb-step`)
 --------------------------
 
 ### `student_view_data`
 
-- `type`: Always equals `"sb-step"` for Mentoring Step components (string).
-- `title`: Step component's display name (string).
-- `show_title`: `true` if the title should be displayed (boolean).
-- `next_button_label`: Text label of the "Next Step" button (string).
-- `message`: Feedback or instructional message which should be displayed after
-  student submits the step (string).
-- `components`: A list of `student_view_data` output of all immediate child
-  components which implement `student_view_data`. Child components which don't
-  implement `student_view_data` are omitted from the list (array).
+- `type`: (string) Always equals `"sb-step"` for Mentoring Step components.
+- `title`: (string) Step component's display name.
+- `show_title`: (boolean) `true` if the title should be displayed.
+- `next_button_label`: (string) Text label of the "Next Step" button.
+- `message`: (string) Feedback or instructional message which should be
+  displayed after student submits the step. May be `null`.
+- `components`: (array) A list of `student_view_data` output of all immediate
+  child components which implement `student_view_data`. Child components which
+  don't implement `student_view_data` are omitted from the list.
 
 ### `student_view_user_state`
 
-- `student_results`: Same as `student_results` described under
+- `student_results`: (array) Same as `student_results` described under
   `student_view_user_state` in the Problem Builder section.
-- `components`: Same as `components` described under `student_view_user_state`
-  in the Problem Builder section.
+- `components`: (object) Same as `components` described under
+  `student_view_user_state` in the Problem Builder section.
 
 Review Step (`sb-review-step`)
 ------------------------------
 
 ### `student_view_data`
 
-- `type`: Always equals `"sb-review-step`" for Review Step components (string).
-- `title`: Display name of the component (string).
-- `components`: A list of `student_view_data` output of all immediate child
-  components which implement `student_view_data`. Child components which don't
-  implement `student_view_data` are omitted from the list (array).
+- `type`: (string) Always equals `"sb-review-step`" for Review Step components.
+- `title`: (string) Display name of the component.
+- `components`: (array) A list of `student_view_data` output of all immediate
+  child components which implement `student_view_data`. Child components which
+  don't implement `student_view_data` are omitted from the list.
 
 Conditional Message (`sb-conditional-message`)
 ----------------------------------------------
@@ -164,254 +193,256 @@ Conditional Message component is always child of a Review Step component.
 
 ### `student_view_data`
 
-- `type`: Always equals `"sb-conditional-message"` for Conditional Message
-  components (string).
-- `content`: Content of the message. May contain HTML (string).
-- `score_condition`: One of `"perfect"`, `"imperfect"`, or `"any"` (string).
-- `num_attempts_condition`: One of `"can_try_again"`, `"cannot_try_again"`, or
-  `"any"` (string).
+- `type`: (string) Always equals `"sb-conditional-message"` for Conditional
+  Message components.
+- `content`: (string) Content of the message. May contain HTML.
+- `score_condition`: (string) One of `"perfect"`, `"imperfect"`, or `"any"`.
+- `num_attempts_condition`: (string) One of `"can_try_again"`,
+  `"cannot_try_again"`, or `"any"`.
 
 Score Summary (`sb-review-score`)
 ---------------------------------
 
 ### `student_view_data`
 
-- `type`: Always equals `"sb-review-score"` for Score Summary components
-  (string).
+- `type`: (string) Always equals `"sb-review-score"` for Score Summary
+  components.
 
 Per-Question Feedback (`sb-review-per-question-feedback`)
 ---------------------------------------------------------
 
 ### `student_view_data`
 
-- `type`: Always equals `"sb-review-per-question-feedback"` for Score Summary
-  components (string).
+- `type`: (string) Always equals `"sb-review-per-question-feedback"` for Score
+  Summary components.
 
 Long Answer (`pb-answer`)
 -------------------------
 
 ### `student_view_data`
 
-- `type`: Always equals `"pb-answer"` for Long Answer components (string).
-- `id`: Unique ID (name) of the component (string).
-- `weight`: The weight of this component (float).
-- `question`: The question/text displayed above the input field (string).
+- `type`: (string) Always equals `"pb-answer"` for Long Answer components.
+- `id`: (string) Unique ID (name) of the component.
+- `weight`: (float) The weight of this component.
+- `question`: (string) The question/text displayed above the input field.
 
 ### `student_view_user_state`
 
-- `answer_data`: A dict with info about students submitted answer. See below for
-  more info(object).
+- `answer_data`: (object) A dict with info about students submitted answer. See
+  below for more info.
 
 #### `answer_data`
 
 The `answer_data` field contains these items:
 
-- `student_input`: Text that the student entered (string).
-- `created_on`: Date/Time when the answer was first submitted (string).
-- `modified_on`: Date/Time when the answer was last modified (string).
+- `student_input`: (string) Text that the student entered.
+- `created_on`: (string) Date/Time when the answer was first submitted.
+- `modified_on`: (string) Date/Time when the answer was last modified.
 
 ### `student_results`
 
-- `status`: One of `"correct"` or `"incorrect"` (string).
-- `score`: Student's score. One of `1` or `0` (integer).
-- `weight`: Child component's weight attribute (float).
-- `student_input`: Text entered by the user (string).
+- `status`: (string) One of `"correct"` or `"incorrect"`.
+- `score`: (integer) Student's score. One of `1` or `0`.
+- `weight`: (float) Child component's weight attribute.
+- `student_input`: (string) Text entered by the user.
 
 ### POST Submit Data
 
 When submitting the problem either via Problem Builder or Step Builder, the data
 entry corresponding to the Long Answer block should be an array with a single
-object containing the `"value"` property: `[{"value": "Student's input"}]`.
+object containing the `"value"` property. Example: `[{"value": "Student's input"}]`.
 
 Multiple Choice Question (`pb-mcq`)
 -----------------------------------
 
 ### `student_view_data`
 
-- `type`: Always equals `"pb-mcq"` for MCQ components (string).
-- `id`: Unique ID (name) of the component (string).
-- `question`: The content of the question (string).
-- `message`: General feedback provided when submitting (string).
-- `weight`: The weight of the problem (float).
-- `choices`: A list of objects providing info about available choices. See below
-  for more info (array).
-- `tips`: A list of objects providing info about tips defined for the
-  problem. See below for more info (array).
+- `type`: (string) Always equals `"pb-mcq"` for MCQ components.
+- `id`: (string) Unique ID (name) of the component.
+- `question`: (string) The content of the question.
+- `message`: (string) General feedback provided when submitting.
+- `weight`: (float) The weight of the problem.
+- `choices`: (array) A list of objects providing info about available
+  choices. See below for more info.
+- `tips`: (array) A list of objects providing info about tips defined for the
+  problem. See below for more info.
 
 #### `choices`
 
 Each entry in the `choices` array contains these values:
 
-- `content`: Display name of the choice (string).
-- `value`: The value of the choice. This is the value that gets submitted and
-  stored when users submits their answer (string).
+- `content`: (string) Display name of the choice.
+- `value`: (string) The value of the choice. This is the value that gets
+  submitted and stored when users submits their answer.
 
 #### `tips`
 
 Each entry in the `tips` array contains these values:
 
-- `content`: The text content of the tip (string).
-- `for_choices`: A list of string values corresponding to choices to which this
-  tip applies to (array).
+- `content`: (string) The text content of the tip.
+- `for_choices`: (array) A list of string values corresponding to choices to
+  which this tip applies to.
 
 ### `student_view_user_state`
 
-- `student_choice`: The value of the last submitted choice (string).
+- `student_choice`: (string) The value of the last submitted choice.
 
 ### `student_results`
 
-- `status`: One of `"correct"` or `"incorrect"` (string).
-- `score`: Student's score. One of `1` or `0` (integer).
-- `weight`: Child component's weight attribute (float).
-- `submission`: The value of the choice that the user selected (string).
-- `message`: General feedback. May contain HTML (string).
-- `tips`: HTML representation of tips. May be `null` (string).
+- `status`: (string) One of `"correct"` or `"incorrect"`.
+- `score`: (integer) Student's score. One of `1` or `0`.
+- `weight`: (float) Child component's weight attribute.
+- `submission`: (string) The value of the choice that the user selected.
+- `message`: (string) General feedback. May contain HTML.
+- `tips`: (string) HTML representation of tips. May be `null`.
 
 ### POST Submit Data
 
-When submitting the problem the data should equal to the string value of the
-selected choice.
+When submitting the problem the data should be equal to the string value of the
+selected choice. Example: `"blue"`.
 
 Rating Question (`pb-rating`)
 -----------------------------
 
 ### `student_view_data`
 
-Identical to MCQ questions except that the `type` field always equals
-`"pb-rating"`.
+Identical to [MCQ questions](#multiple-choice-question-pb-mcq) except that the
+`type` field always equals `"pb-rating"`.
 
 ### `student_view_user_state`
 
-- `student_choice`: The value of the last submitted choice (string).
+- `student_choice`: (string) The value of the last submitted choice.
 
 ### `student_results`
 
-Identical to MCQ questions.
+Identical to [MCQ questions](#multiple-choice-question-pb-mcq).
 
 ### POST Submit Data
 
-When submitting the problem the data should equal to the string value of the
-selected choice.
+When submitting the problem the data should be equal to the string value of the
+selected choice. Example: `"3"`.
 
 Multiple Response Question (`pb-mrq`)
 -------------------------------------
 
 ### `student_view_data`
 
-- `type`: Always equals `"pb-mrq"` for Multiple Response Question components
-  (string).
-- `id`: Unique ID (name) of the component (string).
-- `title`: Display name of the component (string).
-- `weight`: Weight of the problem (float).
-- `question`: The content of the question (string).
-- `message`: General feedback provided when submitting (string).
-- `hide_results`: `true` if results should be hidden (boolean).
+- `type`: (string) Always equals `"pb-mrq"` for Multiple Response Question
+  components.
+- `id`: (string) Unique ID (name) of the component.
+- `title`: (string) Display name of the component.
+- `weight`: (float) Weight of the problem.
+- `question`: (string) The content of the question.
+- `message`: (string) General feedback provided when submitting.
+- `hide_results`: (boolean) `true` if results should be hidden.
 
 ### `student_view_user_state`
 
-- `student_choices`: A list of string values corresponding to choices last
-  submitted by the student (array).
+- `student_choices`: (array) A list of string values corresponding to choices
+  last submitted by the student.
 
 ### `student_results`
 
-- `status`: One of `"correct"`, `"incorrect"`, or `"partial"` (string).
-- `score`: Student's score. Float in the range `0 - 1` (float).
-- `weight`: Child component's weight attribute (float).
-- `submissions`: A list of string values corresponding to the choices that the
-  user selected (array).
-- `message`: General feedback. May contain HTML (string).
-- `choices`: A list of dicts containing info about available choices. See below
-  for more info (array).
+- `status`: (string) One of `"correct"`, `"incorrect"`, or `"partial"`.
+- `score`: (float) Student's score. Float in the range `0 - 1`.
+- `weight`: (float) Child component's weight attribute.
+- `submissions`: (array) A list of string values corresponding to the choices
+  that the user selected.
+- `message`: (string) General feedback. May contain HTML.
+- `choices`: (array) A list of dicts containing info about available
+  choices. See below for more info.
 
 #### `choices`
 
 Each item in the `choices` array contains these fields:
 
-- `completed`: Boolean indicating whether the state of the choice is correct
-  (boolean).
-- `selected`: `true` if the user selected this choice (boolean).
-- `tips`: Tips formatted as a string of HTML (string).
-- `value`: The value of the choice (string).
+- `completed`: (boolean) Boolean indicating whether the state of the choice is
+  correct.
+- `selected`: (boolean) `true` if the user selected this choice.
+- `tips`: (string) Tips formatted as a string of HTML.
+- `value`: (string) The value of the choice.
 
 ### POST Submit Data
 
 The submitted data should be a JSON array of string values corresponding to
-selected choices.
+selected choices. Example: `["red","blue"]`.
 
 Ranged Value Slider (`pb-slider`)
 ---------------------------------
 
 ### `student_view_data`
 
-- `type`: Always equals `"pb-slider"` for Ranged Value Slider components (string).
-- `id`: Unique ID (name) of the component (string).
-- `title`: Display name of the component (string).
-- `hide_header`: `true` if header should be hidden (boolean).
-- `question`: The content of the question (string).
-- `min_label`: Label for the low end of the range (string).
-- `max_label`: Label for the high end of the range (string).
+- `type`: (string) Always equals `"pb-slider"` for Ranged Value Slider
+  components.
+- `id`: (string) Unique ID (name) of the component.
+- `title`: (string) Display name of the component.
+- `hide_header`: (boolean) `true` if header should be hidden.
+- `question`: (string) The content of the question.
+- `min_label`: (string) Label for the low end of the range.
+- `max_label`: (string) Label for the high end of the range.
 
 ### `student_view_user_state`
 
-- `student_value`: The value last selected by the user (float).
+- `student_value`: (float) The value last selected by the user.
 
 ### `student_results`
 
-- `status`: Always `"correct"` for Ranged Value Slider components (string).
-- `score`: Always equals `1` for Ranged Value Slider components (integer).
-- `weight`: Child component's weight attribute (float).
-- `submission`: The float value of the user submission, or `null` if the
-  component has never been submitted (float).
+- `status`: (string) Always `"correct"` for Ranged Value Slider components.
+- `score`: (integer) Always equals `1` for Ranged Value Slider components.
+- `weight`: (float) Child component's weight attribute.
+- `submission`: (float) The float value of the user submission, or `null` if the
+  component has never been submitted.
 
 ### POST Submit Data
 
 The submitted data should be a float value representing the value selected by
-the user.
+the user. Example: `0.65`.
 
 Completion (`pb-completion`)
 ----------------------------
 
 ### `student_view_data`
 
-- `type`: Always equals `"pb-completion"` for Completion components (string).
-- `id`: Unique ID (name) of the component (string).
-- `title`: Display name of the problem (string).
-- `hide_header`: `true` if the header should be hidden (boolean).
-- `question`: The content of the question (string).
-- `answer`: Represents the answer that the student can (un)check (string).
+- `type`: (string) Always equals `"pb-completion"` for Completion components.
+- `id`: (string) Unique ID (name) of the component.
+- `title`: (string) Display name of the problem.
+- `hide_header`: (boolean) `true` if the header should be hidden.
+- `question`: (string) The content of the question.
+- `answer`: (string) Represents the answer that the student can (un)check.
 
 ### `student_view_user_state`
 
-- `student_value`: Boolean indicating whether the user checked the checkbox. Can
-  also be `null` if the user never checked or unchecked the checkbox (boolean).
+- `student_value`: (boolean) Boolean indicating whether the user checked the
+  checkbox. Can also be `null` if the user never checked or unchecked the
+  checkbox.
 
 ### `student_results`
 
-- `status`: Always `"correct"` for Completion components (string).
-- `score`: Always equals `1` for Completion components (integer).
-- `weight`: Child component's weight attribute (float).
-- `submission`: The boolean value of the user submission, or `null` if the
-  component has never been submitted (boolean).
+- `status`: (string) Always `"correct"` for Completion components.
+- `score`: (integer) Always equals `1` for Completion components.
+- `weight`: (float) Child component's weight attribute.
+- `submission`: (boolean) The boolean value of the user submission, or `null` if
+  the component has never been submitted.
 
 ### POST Submit Data
 
 The submitted data should be JSON boolean, `true` if the checkbox is checked and
-`false` if it is not.
+`false` if it is not. Example: `true`.
 
 Plot (`sb-plot`)
 ----------------
 
 ### `student_view_data`
 
-- `type`: Always equals `"sb-plot"` for Plot components (string).
-- `title`: Display name of the component (string).
-- `q1_label`: Quadrant I label (string).
-- `q2_label`: Quadrant II label (string).
-- `q3_label`: Quadrant III label (string).
-- `q4_label`: Quadrant IV label (string).
-- `point_color_default`: Point color to use for default overlay (string).
-- `plot_label`: Label for default overlay which shows student's answers to scale
-  questions (string).
-- `point_color_average`: Point color to use for the average overlay (string).
-- `overlay_data`: JSON data representing points on overlays (string).
-- `hide_header': Always `true` for Plot components (boolean).
+- `type`: (string) Always equals `"sb-plot"` for Plot components.
+- `title`: (string) Display name of the component.
+- `q1_label`: (string) Quadrant I label.
+- `q2_label`: (string) Quadrant II label.
+- `q3_label`: (string) Quadrant III label.
+- `q4_label`: (string) Quadrant IV label.
+- `point_color_default`: (string) Point color to use for default overlay
+  (string). - `plot_label`: Label for default overlay which shows student's
+  answers to scale questions.
+- `point_color_average`: (string) Point color to use for the average overlay.
+- `overlay_data`: (string) JSON data representing points on overlays.
+- `hide_header`: (boolean) Always `true` for Plot components.

--- a/doc/Native APIs.md
+++ b/doc/Native APIs.md
@@ -1,0 +1,417 @@
+Native API Documentation
+========================
+
+This documents the APIs that can be used to implement native wrappers. There are
+three types of APIs:
+
+- `student_view_data`: Exposes block settings and content as JSON data. Can be
+  retrieved via the edX Course Blocks API. Does not include user-specific data
+  (i.e. items derived from `Scope.user_state` fields).
+- `student_view_user_state`: XBlock handler which returns user state data in
+  JSON format.
+- Custom XBlock handlers used for submitting user input and recording user actions.
+
+Problem Builder (`problem-builder`)
+-----------------------------------
+
+### `student_view_data`
+
+- `max_attempts`: Max number of allowed attempts (integer).
+- `extended_feedback`: `true` if extended feedback is enabled for this block
+  (boolean).
+- `feedback_label`: Feedback message header (string).
+- `messages`: A dict with three string entries: `completed`, `incomplete`, and
+  `max_attempts_reached`. See below for info on each (object).
+- `components`: A list of `student_view_data` output of all immediate child
+  components which implement `student_view_data`. Child components which don't
+  implement `student_view_data` are omitted from the list (array).
+
+#### `messages`
+
+These messages are displayed as feedback, depending on the state of the block.
+
+- `completed`: Message to be shown if the user successfully completes the
+  problem. May contain HTML (string).
+- `incomplete`: Message to be shown if the user did not successfully complete
+  the problem, but still has available attempts left. May contain HTML (string).
+- `max_attempts_reached`: Message to be shown if the user did not complete the
+  problem and has no available attempts left.
+
+### `student_view_user_state`
+
+- `num_attempts`: Number of attempts used so far (integer).
+- `completed`: `true` if the user successfully completed the problem at least
+  once (boolean).
+- `student_results`: A list of user submitted answers with metadata for each
+  child component. See below for more info (array).
+- `components`: A dict of `student_view_user_state` output of all immediate
+  child components which implement `student_view_user_state`. Dict keys are
+  component IDs and the value corresponding to each key is the output of
+  `student_view_user_state`(object). Child components which don't implement
+  `student_view_user_state` are not included in the dict.
+
+#### `student_results`
+
+The `student_results` field is an array of two-element arrays. Each nested array
+has the form of `[component_name, data]`. Only components which the student
+already submitted are present in the array. The structure of the `data` object
+depends on the type of the child component and is described separately for each
+type of child component below.
+
+### Custom Handlers
+
+#### `submit`
+
+The `submit` XBlock JSON handler is used for submitting student input. The
+`POST` data should be a dict where keys are child component names. The values
+depend on the component type and are described separately for each type of child
+component below.
+
+Returns a JSON object which contains these fields:
+
+- `results`: Same as `student_results` described under
+  `student_view_user_state` above.
+- `completed`: Same as `completed` described under `student_view_user_state`
+  above.
+- `message`: One of the `completed`, `incomplete`, or `max_attempts_reached`
+  feedback messages described under `messages` above. Can be `null` if no
+  messages has been defined. May contain HTML (string).
+- `max_attempts`: Same as `max_attempts` under `student_view_data`.
+- `num_attempts`: Same as `num_attempts` under `student_view_user_state`.
+
+
+Step Builder (`step-builder`)
+-----------------------------
+
+### `student_view_data`
+
+- `title`: The display name of the component (string).
+- `show_title`: `true` if the title should be displayed (boolean).
+- `weight`: The weight of the problem (float).
+- `extended_feedback`: `true` if extended feedback is enabled for this block
+  (boolean).
+- `max_attempts`: Max number of allowed attempts (integer).
+- `components`: A list of `student_view_data` output of all immediate child
+  components which implement `student_view_data`. For `step-builder`, immediate
+  children are typically `sb-step` and `sb-review-step` type components. Child
+  components which don't implement `student_view_data` are omitted from the list
+  (array).
+
+### `student_view_user_state`
+
+Same as Problem Builder above, but also contains these additional fields:
+
+- `active_step`: The index of the step which is currently active. Starts at zero
+  (integer).
+
+### Custom Handlers
+
+#### `submit`
+
+The `submit` XBlock JSON handler is used for submitting student input. The
+`POST` data should be a dict where keys are child component names. The values
+depend on the component type and are described separately for each type of child
+component below.
+
+In addition to child component names, the `POST` data should also include the
+`active_step` field. The value should be the index of the current step.
+
+#### `try_again`
+
+The `try_again` XBlock JSON handler can be used when the student reaches the
+final step. Sending a `POST` request to `try_again` will reset the problem and
+all of its children.
+
+Returns a JSON object containing the new value of `active_step`.
+
+Mentoring Step (`sb-step`)
+--------------------------
+
+### `student_view_data`
+
+- `type`: Always equals `"sb-step"` for Mentoring Step components (string).
+- `title`: Step component's display name (string).
+- `show_title`: `true` if the title should be displayed (boolean).
+- `next_button_label`: Text label of the "Next Step" button (string).
+- `message`: Feedback or instructional message which should be displayed after
+  student submits the step (string).
+- `components`: A list of `student_view_data` output of all immediate child
+  components which implement `student_view_data`. Child components which don't
+  implement `student_view_data` are omitted from the list (array).
+
+### `student_view_user_state`
+
+- `student_results`: Same as `student_results` described under
+  `student_view_user_state` in the Problem Builder section.
+- `components`: Same as `components` described under `student_view_user_state`
+  in the Problem Builder section.
+
+Review Step (`sb-review-step`)
+------------------------------
+
+### `student_view_data`
+
+- `type`: Always equals `"sb-review-step`" for Review Step components (string).
+- `title`: Display name of the component (string).
+- `components`: A list of `student_view_data` output of all immediate child
+  components which implement `student_view_data`. Child components which don't
+  implement `student_view_data` are omitted from the list (array).
+
+Conditional Message (`sb-conditional-message`)
+----------------------------------------------
+
+Conditional Message component is always child of a Review Step component.
+
+### `student_view_data`
+
+- `type`: Always equals `"sb-conditional-message"` for Conditional Message
+  components (string).
+- `content`: Content of the message. May contain HTML (string).
+- `score_condition`: One of `"perfect"`, `"imperfect"`, or `"any"` (string).
+- `num_attempts_condition`: One of `"can_try_again"`, `"cannot_try_again"`, or
+  `"any"` (string).
+
+Score Summary (`sb-review-score`)
+---------------------------------
+
+### `student_view_data`
+
+- `type`: Always equals `"sb-review-score"` for Score Summary components
+  (string).
+
+Per-Question Feedback (`sb-review-per-question-feedback`)
+---------------------------------------------------------
+
+### `student_view_data`
+
+- `type`: Always equals `"sb-review-per-question-feedback"` for Score Summary
+  components (string).
+
+Long Answer (`pb-answer`)
+-------------------------
+
+### `student_view_data`
+
+- `type`: Always equals `"pb-answer"` for Long Answer components (string).
+- `id`: Unique ID (name) of the component (string).
+- `weight`: The weight of this component (float).
+- `question`: The question/text displayed above the input field (string).
+
+### `student_view_user_state`
+
+- `answer_data`: A dict with info about students submitted answer. See below for
+  more info(object).
+
+#### `answer_data`
+
+The `answer_data` field contains these items:
+
+- `student_input`: Text that the student entered (string).
+- `created_on`: Date/Time when the answer was first submitted (string).
+- `modified_on`: Date/Time when the answer was last modified (string).
+
+### `student_results`
+
+- `status`: One of `"correct"` or `"incorrect"` (string).
+- `score`: Student's score. One of `1` or `0` (integer).
+- `weight`: Child component's weight attribute (float).
+- `student_input`: Text entered by the user (string).
+
+### POST Submit Data
+
+When submitting the problem either via Problem Builder or Step Builder, the data
+entry corresponding to the Long Answer block should be an array with a single
+object containing the `"value"` property: `[{"value": "Student's input"}]`.
+
+Multiple Choice Question (`pb-mcq`)
+-----------------------------------
+
+### `student_view_data`
+
+- `type`: Always equals `"pb-mcq"` for MCQ components (string).
+- `id`: Unique ID (name) of the component (string).
+- `question`: The content of the question (string).
+- `message`: General feedback provided when submitting (string).
+- `weight`: The weight of the problem (float).
+- `choices`: A list of objects providing info about available choices. See below
+  for more info (array).
+- `tips`: A list of objects providing info about tips defined for the
+  problem. See below for more info (array).
+
+#### `choices`
+
+Each entry in the `choices` array contains these values:
+
+- `content`: Display name of the choice (string).
+- `value`: The value of the choice. This is the value that gets submitted and
+  stored when users submits their answer (string).
+
+#### `tips`
+
+Each entry in the `tips` array contains these values:
+
+- `content`: The text content of the tip (string).
+- `for_choices`: A list of string values corresponding to choices to which this
+  tip applies to (array).
+
+### `student_view_user_state`
+
+- `student_choice`: The value of the last submitted choice (string).
+
+### `student_results`
+
+- `status`: One of `"correct"` or `"incorrect"` (string).
+- `score`: Student's score. One of `1` or `0` (integer).
+- `weight`: Child component's weight attribute (float).
+- `submission`: The value of the choice that the user selected (string).
+- `message`: General feedback. May contain HTML (string).
+- `tips`: HTML representation of tips. May be `null` (string).
+
+### POST Submit Data
+
+When submitting the problem the data should equal to the string value of the
+selected choice.
+
+Rating Question (`pb-rating`)
+-----------------------------
+
+### `student_view_data`
+
+Identical to MCQ questions except that the `type` field always equals
+`"pb-rating"`.
+
+### `student_view_user_state`
+
+- `student_choice`: The value of the last submitted choice (string).
+
+### `student_results`
+
+Identical to MCQ questions.
+
+### POST Submit Data
+
+When submitting the problem the data should equal to the string value of the
+selected choice.
+
+Multiple Response Question (`pb-mrq`)
+-------------------------------------
+
+### `student_view_data`
+
+- `type`: Always equals `"pb-mrq"` for Multiple Response Question components
+  (string).
+- `id`: Unique ID (name) of the component (string).
+- `title`: Display name of the component (string).
+- `weight`: Weight of the problem (float).
+- `question`: The content of the question (string).
+- `message`: General feedback provided when submitting (string).
+- `hide_results`: `true` if results should be hidden (boolean).
+
+### `student_view_user_state`
+
+- `student_choices`: A list of string values corresponding to choices last
+  submitted by the student (array).
+
+### `student_results`
+
+- `status`: One of `"correct"`, `"incorrect"`, or `"partial"` (string).
+- `score`: Student's score. Float in the range `0 - 1` (float).
+- `weight`: Child component's weight attribute (float).
+- `submissions`: A list of string values corresponding to the choices that the
+  user selected (array).
+- `message`: General feedback. May contain HTML (string).
+- `choices`: A list of dicts containing info about available choices. See below
+  for more info (array).
+
+#### `choices`
+
+Each item in the `choices` array contains these fields:
+
+- `completed`: Boolean indicating whether the state of the choice is correct
+  (boolean).
+- `selected`: `true` if the user selected this choice (boolean).
+- `tips`: Tips formatted as a string of HTML (string).
+- `value`: The value of the choice (string).
+
+### POST Submit Data
+
+The submitted data should be a JSON array of string values corresponding to
+selected choices.
+
+Ranged Value Slider (`pb-slider`)
+---------------------------------
+
+### `student_view_data`
+
+- `type`: Always equals `"pb-slider"` for Ranged Value Slider components (string).
+- `id`: Unique ID (name) of the component (string).
+- `title`: Display name of the component (string).
+- `hide_header`: `true` if header should be hidden (boolean).
+- `question`: The content of the question (string).
+- `min_label`: Label for the low end of the range (string).
+- `max_label`: Label for the high end of the range (string).
+
+### `student_view_user_state`
+
+- `student_value`: The value last selected by the user (float).
+
+### `student_results`
+
+- `status`: Always `"correct"` for Ranged Value Slider components (string).
+- `score`: Always equals `1` for Ranged Value Slider components (integer).
+- `weight`: Child component's weight attribute (float).
+- `submission`: The float value of the user submission, or `null` if the
+  component has never been submitted (float).
+
+### POST Submit Data
+
+The submitted data should be a float value representing the value selected by
+the user.
+
+Completion (`pb-completion`)
+----------------------------
+
+### `student_view_data`
+
+- `type`: Always equals `"pb-completion"` for Completion components (string).
+- `id`: Unique ID (name) of the component (string).
+- `title`: Display name of the problem (string).
+- `hide_header`: `true` if the header should be hidden (boolean).
+- `question`: The content of the question (string).
+- `answer`: Represents the answer that the student can (un)check (string).
+
+### `student_view_user_state`
+
+- `student_value`: Boolean indicating whether the user checked the checkbox. Can
+  also be `null` if the user never checked or unchecked the checkbox (boolean).
+
+### `student_results`
+
+- `status`: Always `"correct"` for Completion components (string).
+- `score`: Always equals `1` for Completion components (integer).
+- `weight`: Child component's weight attribute (float).
+- `submission`: The boolean value of the user submission, or `null` if the
+  component has never been submitted (boolean).
+
+### POST Submit Data
+
+The submitted data should be JSON boolean, `true` if the checkbox is checked and
+`false` if it is not.
+
+Plot (`sb-plot`)
+----------------
+
+### `student_view_data`
+
+- `type`: Always equals `"sb-plot"` for Plot components (string).
+- `title`: Display name of the component (string).
+- `q1_label`: Quadrant I label (string).
+- `q2_label`: Quadrant II label (string).
+- `q3_label`: Quadrant III label (string).
+- `q4_label`: Quadrant IV label (string).
+- `point_color_default`: Point color to use for default overlay (string).
+- `plot_label`: Label for default overlay which shows student's answers to scale
+  questions (string).
+- `point_color_average`: Point color to use for the average overlay (string).
+- `overlay_data`: JSON data representing points on overlays (string).
+- `hide_header': Always `true` for Plot components (boolean).

--- a/problem_builder/completion.py
+++ b/problem_builder/completion.py
@@ -116,9 +116,8 @@ class CompletionBlock(
             'type': self.CATEGORY,
             'question': self.question,
             'answer': self.answer,
-            'checked': self.student_value if self.student_value is not None else False,
             'title': self.display_name_with_default,
-            'hide_header': self.show_title,
+            'hide_header': not self.show_title,
         }
 
     def get_last_result(self):

--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -1262,9 +1262,6 @@ class MentoringWithExplicitStepsBlock(BaseMentoringBlock, StudioContainerWithNes
             'show_title': self.show_title,
             'weight': self.weight,
             'extended_feedback': self.extended_feedback,
-            'active_step': self.active_step_safe,
             'max_attempts': self.max_attempts,
-            'num_attempts': self.num_attempts,
-            'hide_prev_answer': True,
             'components': components,
         }

--- a/problem_builder/plot.py
+++ b/problem_builder/plot.py
@@ -358,13 +358,12 @@ class PlotBlock(StudioEditableXBlockMixin, StudioContainerWithNestedXBlocksMixin
             'q2_label': self.q2_label,
             'q3_label': self.q3_label,
             'q4_label': self.q4_label,
-            'default_claims_json': self.default_claims_json(),
             'point_color_default': self.point_color_default,
             'plot_label': self.plot_label,
-            'average_claims_json': self.average_claims_json(),
             'point_color_average': self.point_color_average,
             'overlay_data': self.overlay_data,
             'hide_header': True,
+            'claims': self.claims,
         }
 
     def author_edit_view(self, context):

--- a/problem_builder/slider.py
+++ b/problem_builder/slider.py
@@ -127,7 +127,6 @@ class SliderBlock(
             'id': self.name,
             'type': self.CATEGORY,
             'question': self.question,
-            'initial_value': int(self.student_value*100) if self.student_value is not None else 50,
             'min_label': self.min_label,
             'max_label': self.max_label,
             'title': self.display_name_with_default,

--- a/problem_builder/step_review.py
+++ b/problem_builder/step_review.py
@@ -164,7 +164,6 @@ class ScoreSummaryBlock(XBlockWithTranslationServiceMixin, XBlockWithPreviewMixi
 
         return {
             'type': self.CATEGORY,
-            'score_summary': context.get('score_summary', {}),
         }
 
     embedded_student_view = student_view
@@ -221,7 +220,6 @@ class PerQuestionFeedbackBlock(XBlockWithTranslationServiceMixin, XBlockWithPrev
 
         return {
             'type': self.CATEGORY,
-            'tips': review_tips
         }
 
     embedded_student_view = student_view

--- a/problem_builder/step_review.py
+++ b/problem_builder/step_review.py
@@ -215,9 +215,6 @@ class PerQuestionFeedbackBlock(XBlockWithTranslationServiceMixin, XBlockWithPrev
         return Fragment(html)
 
     def student_view_data(self, context=None):
-        context = context or {}
-        review_tips = context.get('score_summary', {}).get('review_tips')
-
         return {
             'type': self.CATEGORY,
         }

--- a/problem_builder/tests/unit/test_step_builder.py
+++ b/problem_builder/tests/unit/test_step_builder.py
@@ -48,9 +48,7 @@ class TestMentoringBlock(BlockWithChildrenTestMixin, unittest.TestCase):
             'show_title': False,
             'weight': 5.0,
             'max_attempts': 3,
-            'num_attempts': 2,
             'extended_feedback': True,
-            'active_step': 0,
         }
         step_builder = make_block(MentoringWithExplicitStepsBlock, step_builder_data)
 
@@ -96,10 +94,7 @@ class TestMentoringBlock(BlockWithChildrenTestMixin, unittest.TestCase):
             'show_title': step_builder_data['show_title'],
             'weight': step_builder_data['weight'],
             'max_attempts': step_builder_data['max_attempts'],
-            'num_attempts': step_builder_data['num_attempts'],
             'extended_feedback': step_builder_data['extended_feedback'],
-            'active_step': step_builder_data['active_step'],
-            'hide_prev_answer': True,
             'components': [
                 {
                     'type': 'sb-step',
@@ -115,7 +110,6 @@ class TestMentoringBlock(BlockWithChildrenTestMixin, unittest.TestCase):
                     'components': [
                         {
                             'type': 'sb-review-score',
-                            'score_summary': {},
                         },
                         {
                             'type': 'sb-conditional-message',


### PR DESCRIPTION
This documents `student_view_data`, `student_view_user_state`, and custom handlers for each supported component.

**Notes and Concerns**:

The APIs are not very consistent between some components. Some APIs consume data in weird shape, most notably [freeform answer submit handler](https://github.com/open-craft/problem-builder/blob/502d6eeea33a364261ee36c3e5dcbd40134ec0f1/doc/Native%20APIs.md#post-submit-data), probably because it was never designed to be public.

Currently `components` entry in `student_view_user_state` is a dict where keys edX block keys (i.e. `'i4x://TstCrs/TS111/pb-answer/a0b04a13d3074229b6be33fbc31de233'`), but in `student_view_data` we typically use our internal customizable unique IDs (`self.name`).
We might want to make that more consistent.

I don't like how we simply expose all `Scope.user_state` fields in `student_view_user_state` by default. We should hand pick the fields that we want to expose directly instead, and we might also prefer to include data derived from user state in a form that is more suitable for API consumers. We perform normalizations in several places internally, which is skipped if we expose the fields directly.

**Reviewers**:

- [ ] @pomegranited 