### PR TITLE
[OC-2874] Added choices and tips to MRQ student_view_data

### DIFF
--- a/problem_builder/mrq.py
+++ b/problem_builder/mrq.py
@@ -203,5 +203,13 @@ class MRQBlock(StudentViewUserStateMixin, QuestionnaireAbstractBlock):
             'weight': self.weight,
             'question': self.question,
             'message': self.message,
+            'choices': [
+                {'value': choice['value'], 'content': choice['display_name']}
+                for choice in self.human_readable_choices
+            ],
             'hide_results': self.hide_results,
+            'tips': [
+                {'content': tip.content, 'for_choices': tip.values}
+                for tip in self.get_tips()
+            ],
         }


### PR DESCRIPTION
This PR extend's the MRQ XBlock to include choices and tips in `student_view_data` output.

**JIRA tickets**: [OC-2874](https://tasks.opencraft.com/browse/OC-2874)

**Dependencies**: None

**Merge deadline**: None

**Testing instructions**:

1. Have a local course with an MRQ, or import the attached course.
2. Find that course ID
3. Go to http://localhost:8000/api/courses/v1/blocks/?all_blocks=true&depth=all&requested_fields=student_view_data&course_id=<course_id>
4. See that there are values for `choices` and `tips` in `student_view_data` for the MRQ.

**Reviewers**
- [x] @mtyaka 

