### PR TITLE
Add simple test for MRQ student_view_data 

### DIFF
--- a/problem_builder/tests/unit/test_problem_builder.py
+++ b/problem_builder/tests/unit/test_problem_builder.py
@@ -7,9 +7,24 @@ from random import random
 from xblock.field_data import DictFieldData
 
 from problem_builder.mcq import MCQBlock
+from problem_builder.mrq import MRQBlock
+
 from problem_builder.mentoring import MentoringBlock, MentoringMessageBlock, _default_options_config
 
 from .utils import BlockWithChildrenTestMixin
+
+
+@ddt.ddt
+class TestMRQBlock(BlockWithChildrenTestMixin, unittest.TestCase):
+    def test_student_view_data(self):
+        """
+        Ensure that all expected fields are always returned.
+        """
+        block = MRQBlock(Mock(), DictFieldData({}), Mock())
+
+        self.assertListEqual(
+            block.student_view_data().keys(),
+            ['hide_results', 'tips', 'weight', 'title', 'question', 'message', 'type', 'id', 'choices'])
 
 
 @ddt.ddt


### PR DESCRIPTION
As @mtyaka and I have discussed, it's difficult to test `student_view_data` methods because:

> complex block hierarchies are hard to set up in tests (see the [test for step builder](https://github.com/open-craft/problem-builder/blob/d191a0e7559207155ba6af56b444048f1ad2d39a/problem_builder/tests/unit/test_step_builder.py) for example), and because the APIs haven't stabilized yet.

To avoid relying on the deprecated`XBlock.field_data` to populate a block's data, I've avoided it completely and written a simple test to ensure that at least the correct keys are always returned by `MRQBlock.student_view_data()`.

**JIRA tickets**: Part of [OC-2874](https://tasks.opencraft.com/browse/OC-2874)

**Merge deadline**: None

**Testing instructions**:

1. Inside the problem-builder repo root and appropriate environment, run 
```./run_tests.py problem_builder/tests/unit/test_problem_builder.py```

**Author notes and concerns**:

1. Is this testing strategy too simple?

**Reviewers**
- [ ] @mtyaka 
