### PR TITLE
OC-2959 freeform and MCQ submitted values are a json and not an array

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ dependencies:
     - "pip install -r requirements.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"
     - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt"
-    - "pip uninstall -y xblock-problem-builder && python setup.py sdist && pip install dist/xblock-problem-builder-2.7.1.tar.gz"
+    - "pip uninstall -y xblock-problem-builder && python setup.py sdist && pip install dist/xblock-problem-builder-2.7.2.tar.gz"
     - "pip install -r test_requirements.txt"
     - "mkdir var"
 test:

--- a/doc/Native APIs.md
+++ b/doc/Native APIs.md
@@ -249,8 +249,8 @@ The `answer_data` field contains these items:
 ### POST Submit Data
 
 When submitting the problem either via Problem Builder or Step Builder, the data
-entry corresponding to the Long Answer block should be an array with a single
-object containing the `"value"` property. Example: `[{"value": "Student's input"}]`.
+entry corresponding to the Long Answer block should be a single object
+containing the `"value"` property. Example: `{"value": "Student's input"}`.
 
 Multiple Choice Question (`pb-mcq`)
 -----------------------------------
@@ -298,8 +298,10 @@ Each entry in the `tips` array contains these values:
 
 ### POST Submit Data
 
-When submitting the problem the data should be equal to the string value of the
-selected choice. Example: `"blue"`.
+When submitting the problem the data should be a single object containing the
+`"value"` property which has the value of the selected choice.
+Example: `{"value": "blue"}`
+
 
 Rating Question (`pb-rating`)
 -----------------------------

--- a/problem_builder/answer.py
+++ b/problem_builder/answer.py
@@ -223,7 +223,7 @@ class AnswerBlock(SubmittingXBlockMixin, AnswerMixin, QuestionMixin, StudioEdita
         The parent block is handling a student submission, including a new answer for this
         block. Update accordingly.
         """
-        self.student_input = submission[0]['value'].strip()
+        self.student_input = submission['value'].strip()
         self.save()
 
         if sub_api:

--- a/problem_builder/mcq.py
+++ b/problem_builder/mcq.py
@@ -125,8 +125,8 @@ class MCQBlock(SubmittingXBlockMixin, StudentViewUserStateMixin, QuestionnaireAb
 
     def submit(self, submission):
         log.debug(u'Received MCQ submission: "%s"', submission)
-        result = self.calculate_results(submission)
-        self.student_choice = submission
+        result = self.calculate_results(submission['value'])
+        self.student_choice = submission['value']
         log.debug(u'MCQ submission result: %s', result)
         return result
 

--- a/problem_builder/public/js/answer.js
+++ b/problem_builder/public/js/answer.js
@@ -15,7 +15,13 @@ function AnswerBlock(runtime, element) {
         },
 
         submit: function() {
-            return $(':input', element).serializeArray();
+            var freeform_answer = $(':input', element);
+
+            if(freeform_answer.length) {
+                return {"value": freeform_answer.val()};
+            } else {
+                return null;
+            }
         },
 
         handleReview: function(result) {

--- a/problem_builder/public/js/questionnaire.js
+++ b/problem_builder/public/js/questionnaire.js
@@ -107,7 +107,7 @@ function MCQBlock(runtime, element) {
             var checkedRadio = $('input[type=radio]:checked', element);
 
             if(checkedRadio.length) {
-                return checkedRadio.val();
+                return {"value": checkedRadio.val()};
             } else {
                 return null;
             }

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='2.7.1',
+    version='2.7.2',
     description='XBlock - Problem Builder',
     packages=['problem_builder', 'problem_builder.v1'],
     install_requires=[


### PR DESCRIPTION
Originally the submission was of the following form:
- For MCQ (multiple-choice questions) it was string value.
- For long/free form answers, it was a json in an array [{<key>: <answer string>}]

This PR makes the submission for both MCQs and freeform answers to the same format, a json with a 'value' key ({"value": <answer string>}). This is so that we can add other info if needed in future.
 