### PR TITLE
define ways to filter and map xblock features into build_user_state_data

### DIFF
--- a/doc/Native APIs.md
+++ b/doc/Native APIs.md
@@ -25,6 +25,7 @@ Problem Builder (`problem-builder`)
 
 ### `student_view_data`
 
+- `block_id`: (string) The XBlock's usage ID.
 - `max_attempts`: (integer) Max number of allowed attempts.
 - `extended_feedback`: (boolean) `true` if extended feedback is enabled for this
   block.
@@ -101,6 +102,7 @@ Step Builder (`step-builder`)
 
 ### `student_view_data`
 
+- `block_id`: (string) The XBlock's usage ID.
 - `title`: (string) The display name of the component.
 - `show_title`: (boolean) `true` if the title should be displayed.
 - `weight`: (float) The weight of the problem.
@@ -158,6 +160,7 @@ Mentoring Step (`sb-step`)
 
 ### `student_view_data`
 
+- `block_id`: (string) The XBlock's usage ID.
 - `type`: (string) Always equals `"sb-step"` for Mentoring Step components.
 - `title`: (string) Step component's display name.
 - `show_title`: (boolean) `true` if the title should be displayed.
@@ -180,6 +183,7 @@ Review Step (`sb-review-step`)
 
 ### `student_view_data`
 
+- `block_id`: (string) The XBlock's usage ID.
 - `type`: (string) Always equals `"sb-review-step`" for Review Step components.
 - `title`: (string) Display name of the component.
 - `components`: (array) A list of `student_view_data` output of all immediate
@@ -193,6 +197,7 @@ Conditional Message component is always child of a Review Step component.
 
 ### `student_view_data`
 
+- `block_id`: (string) The XBlock's usage ID.
 - `type`: (string) Always equals `"sb-conditional-message"` for Conditional
   Message components.
 - `content`: (string) Content of the message. May contain HTML.
@@ -205,6 +210,7 @@ Score Summary (`sb-review-score`)
 
 ### `student_view_data`
 
+- `block_id`: (string) The XBlock's usage ID.
 - `type`: (string) Always equals `"sb-review-score"` for Score Summary
   components.
 
@@ -213,6 +219,7 @@ Per-Question Feedback (`sb-review-per-question-feedback`)
 
 ### `student_view_data`
 
+- `block_id`: (string) The XBlock's usage ID.
 - `type`: (string) Always equals `"sb-review-per-question-feedback"` for Score
   Summary components.
 
@@ -221,6 +228,7 @@ Long Answer (`pb-answer`)
 
 ### `student_view_data`
 
+- `block_id`: (string) The XBlock's usage ID.
 - `type`: (string) Always equals `"pb-answer"` for Long Answer components.
 - `id`: (string) Unique ID (name) of the component.
 - `weight`: (float) The weight of this component.
@@ -257,6 +265,7 @@ Multiple Choice Question (`pb-mcq`)
 
 ### `student_view_data`
 
+- `block_id`: (string) The XBlock's usage ID.
 - `type`: (string) Always equals `"pb-mcq"` for MCQ components.
 - `id`: (string) Unique ID (name) of the component.
 - `question`: (string) The content of the question.
@@ -294,7 +303,6 @@ Each entry in the `tips` array contains these values:
 - `weight`: (float) Child component's weight attribute.
 - `submission`: (string) The value of the choice that the user selected.
 - `message`: (string) General feedback. May contain HTML.
-- `tips`: (string) HTML representation of tips. May be `null`.
 
 ### POST Submit Data
 
@@ -308,6 +316,7 @@ Rating Question (`pb-rating`)
 
 ### `student_view_data`
 
+- `block_id`: (string) The XBlock's usage ID.
 Identical to [MCQ questions](#multiple-choice-question-pb-mcq) except that the
 `type` field always equals `"pb-rating"`.
 
@@ -329,6 +338,7 @@ Multiple Response Question (`pb-mrq`)
 
 ### `student_view_data`
 
+- `block_id`: (string) The XBlock's usage ID.
 - `type`: (string) Always equals `"pb-mrq"` for Multiple Response Question
   components.
 - `id`: (string) Unique ID (name) of the component.
@@ -341,6 +351,14 @@ Multiple Response Question (`pb-mrq`)
   choices. See below for more info.
 - `tips`: (array) A list of objects providing info about tips defined for the
   problem. See below for more info.
+
+#### `tips`
+
+Each entry in the `tips` array contains these values:
+
+- `content`: (string) The text content of the tip.
+- `for_choices`: (array) A list of string values corresponding to choices to
+  which this tip applies to.
 
 ### `student_view_user_state`
 
@@ -365,7 +383,6 @@ Each item in the `choices` array contains these fields:
 - `completed`: (boolean) Boolean indicating whether the state of the choice is
   correct.
 - `selected`: (boolean) `true` if the user selected this choice.
-- `tips`: (string) Tips formatted as a string of HTML.
 - `value`: (string) The value of the choice.
 
 ### POST Submit Data
@@ -378,6 +395,7 @@ Ranged Value Slider (`pb-slider`)
 
 ### `student_view_data`
 
+- `block_id`: (string) The XBlock's usage ID.
 - `type`: (string) Always equals `"pb-slider"` for Ranged Value Slider
   components.
 - `id`: (string) Unique ID (name) of the component.
@@ -409,6 +427,7 @@ Completion (`pb-completion`)
 
 ### `student_view_data`
 
+- `block_id`: (string) The XBlock's usage ID.
 - `type`: (string) Always equals `"pb-completion"` for Completion components.
 - `id`: (string) Unique ID (name) of the component.
 - `title`: (string) Display name of the problem.
@@ -440,6 +459,7 @@ Plot (`sb-plot`)
 
 ### `student_view_data`
 
+- `block_id`: (string) The XBlock's usage ID.
 - `type`: (string) Always equals `"sb-plot"` for Plot components.
 - `title`: (string) Display name of the component.
 - `q1_label`: (string) Quadrant I label.
@@ -452,3 +472,8 @@ Plot (`sb-plot`)
 - `point_color_average`: (string) Point color to use for the average overlay.
 - `overlay_data`: (string) JSON data representing points on overlays.
 - `hide_header`: (boolean) Always `true` for Plot components.
+
+### `student_view_user_state`
+
+- `average_claims`: (array) Averaged claim data
+- `default_claims`: (array) Default claim data

--- a/problem_builder/choice.py
+++ b/problem_builder/choice.py
@@ -75,6 +75,7 @@ class ChoiceBlock(
         retrievable from the Course Block API.
         """
         return {
+            'block_id': unicode(self.scope_ids.usage_id),
             'value': self.value,
             'content': self.content,
         }

--- a/problem_builder/completion.py
+++ b/problem_builder/completion.py
@@ -56,6 +56,8 @@ class CompletionBlock(
     """
     CATEGORY = 'pb-completion'
     STUDIO_LABEL = _(u'Completion')
+    USER_STATE_FIELDS = ['student_value']
+
     answerable = True
 
     question = String(
@@ -113,6 +115,7 @@ class CompletionBlock(
         """
         return {
             'id': self.name,
+            'block_id': unicode(self.scope_ids.usage_id),
             'type': self.CATEGORY,
             'question': self.question,
             'answer': self.answer,

--- a/problem_builder/mcq.py
+++ b/problem_builder/mcq.py
@@ -51,6 +51,7 @@ class MCQBlock(SubmittingXBlockMixin, StudentViewUserStateMixin, QuestionnaireAb
     """
     CATEGORY = 'pb-mcq'
     STUDIO_LABEL = _(u"Multiple Choice Question")
+    USER_STATE_FIELDS = ['num_attempts', 'student_choice']
 
     message = String(
         display_name=_("Message"),
@@ -75,7 +76,7 @@ class MCQBlock(SubmittingXBlockMixin, StudentViewUserStateMixin, QuestionnaireAb
         list_values_provider=QuestionnaireAbstractBlock.choice_values_provider,
         list_style='set',  # Underered, unique items. Affects the UI editor.
     )
-    editable_fields = QuestionnaireAbstractBlock.editable_fields + ('message', 'correct_choices', )
+    editable_fields = QuestionnaireAbstractBlock.editable_fields + ('message', 'correct_choices',)
 
     def describe_choice_correctness(self, choice_value):
         if choice_value in self.correct_choices:
@@ -175,6 +176,7 @@ class MCQBlock(SubmittingXBlockMixin, StudentViewUserStateMixin, QuestionnaireAb
         """
         return {
             'id': self.name,
+            'block_id': unicode(self.scope_ids.usage_id),
             'type': self.CATEGORY,
             'question': self.question,
             'message': self.message,
@@ -183,10 +185,7 @@ class MCQBlock(SubmittingXBlockMixin, StudentViewUserStateMixin, QuestionnaireAb
                 for choice in self.human_readable_choices
             ],
             'weight': self.weight,
-            'tips': [
-                {'content': tip.content, 'for_choices': tip.values}
-                for tip in self.get_tips()
-            ],
+            'tips': [tip.student_view_data() for tip in self.get_tips()],
         }
 
 
@@ -229,7 +228,7 @@ class RatingBlock(MCQBlock):
         display_names = ["1 - {}".format(self.low), "2", "3", "4", "5 - {}".format(self.high)]
         return [
             {"display_name": dn, "value": val} for val, dn in zip(self.FIXED_VALUES, display_names)
-            ] + super(RatingBlock, self).human_readable_choices
+        ] + super(RatingBlock, self).human_readable_choices
 
     def get_author_edit_view_fragment(self, context):
         """

--- a/problem_builder/mrq.py
+++ b/problem_builder/mrq.py
@@ -24,10 +24,10 @@ import logging
 
 from xblock.fields import List, Scope, Boolean, String
 from xblock.validation import ValidationMessage
+from xblockutils.resources import ResourceLoader
 
 from problem_builder.mixins import StudentViewUserStateMixin
 from .questionnaire import QuestionnaireAbstractBlock
-from xblockutils.resources import ResourceLoader
 
 
 # Globals ###########################################################
@@ -48,6 +48,7 @@ class MRQBlock(StudentViewUserStateMixin, QuestionnaireAbstractBlock):
     """
     CATEGORY = 'pb-mrq'
     STUDIO_LABEL = _(u"Multiple Response Question")
+    USER_STATE_FIELDS = ['student_choices', ]
 
     student_choices = List(
         # Last submissions by the student
@@ -139,14 +140,14 @@ class MRQBlock(StudentViewUserStateMixin, QuestionnaireAbstractBlock):
             choice_result = {
                 'value': choice.value,
                 'selected': choice_selected,
-                }
+            }
             # Only include tips/results in returned response if we want to display them
             if not self.hide_results:
                 loader = ResourceLoader(__name__)
                 choice_result['completed'] = choice_completed
                 choice_result['tips'] = loader.render_template('templates/html/tip_choice_group.html', {
                     'tips_html': choice_tips_html,
-                    })
+                })
 
             results.append(choice_result)
 
@@ -198,6 +199,7 @@ class MRQBlock(StudentViewUserStateMixin, QuestionnaireAbstractBlock):
         """
         return {
             'id': self.name,
+            'block_id': unicode(self.scope_ids.usage_id),
             'title': self.display_name,
             'type': self.CATEGORY,
             'weight': self.weight,
@@ -208,8 +210,5 @@ class MRQBlock(StudentViewUserStateMixin, QuestionnaireAbstractBlock):
                 for choice in self.human_readable_choices
             ],
             'hide_results': self.hide_results,
-            'tips': [
-                {'content': tip.content, 'for_choices': tip.values}
-                for tip in self.get_tips()
-            ],
+            'tips': [tip.student_view_data() for tip in self.get_tips()],
         }

--- a/problem_builder/plot.py
+++ b/problem_builder/plot.py
@@ -32,6 +32,7 @@ from xblockutils.resources import ResourceLoader
 from xblockutils.studio_editable import (
     StudioEditableXBlockMixin, StudioContainerWithNestedXBlocksMixin, XBlockWithPreviewMixin
 )
+from .mixins import StudentViewUserStateMixin
 from .sub_api import sub_api
 
 
@@ -59,7 +60,10 @@ def _normalize_id(key):
 
 @XBlock.needs('i18n')
 @XBlock.wants('user')
-class PlotBlock(StudioEditableXBlockMixin, StudioContainerWithNestedXBlocksMixin, XBlockWithPreviewMixin, XBlock):
+class PlotBlock(
+    StudioEditableXBlockMixin, StudioContainerWithNestedXBlocksMixin, XBlockWithPreviewMixin, XBlock,
+    StudentViewUserStateMixin,
+):
     """
     XBlock that displays plot that summarizes answers to scale and/or rating questions.
     """
@@ -238,6 +242,12 @@ class PlotBlock(StudioEditableXBlockMixin, StudioContainerWithNestedXBlocksMixin
 
     def average_claims_json(self):
         return json.dumps(self.average_claims)
+
+    def build_user_state_data(self, context=None):
+        user_state_data = super(PlotBlock, self).build_user_state_data()
+        user_state_data['default_claims'] = self.default_claims
+        user_state_data['average_claims'] = self.average_claims
+        return user_state_data
 
     @XBlock.json_handler
     def get_data(self, data, suffix):

--- a/problem_builder/slider.py
+++ b/problem_builder/slider.py
@@ -57,6 +57,8 @@ class SliderBlock(
     """
     CATEGORY = 'pb-slider'
     STUDIO_LABEL = _(u"Ranged Value Slider")
+    USER_STATE_FIELDS = ['student_value']
+
     answerable = True
 
     min_label = String(
@@ -125,6 +127,7 @@ class SliderBlock(
     def student_view_data(self, context=None):
         return {
             'id': self.name,
+            'block_id': unicode(self.scope_ids.usage_id),
             'type': self.CATEGORY,
             'question': self.question,
             'min_label': self.min_label,

--- a/problem_builder/step.py
+++ b/problem_builder/step.py
@@ -33,7 +33,8 @@ from xblockutils.studio_editable import (
 from problem_builder.answer import AnswerBlock, AnswerRecapBlock
 from problem_builder.completion import CompletionBlock
 from problem_builder.mcq import MCQBlock, RatingBlock
-from problem_builder.mixins import EnumerableChildMixin, StepParentMixin, StudentViewUserStateMixin
+from problem_builder.mixins import (
+    EnumerableChildMixin, StepParentMixin, StudentViewUserStateMixin, StudentViewUserStateResultsTransformerMixin)
 from problem_builder.mrq import MRQBlock
 from problem_builder.plot import PlotBlock
 from problem_builder.slider import SliderBlock
@@ -69,8 +70,9 @@ class Correctness(object):
 
 @XBlock.needs('i18n')
 class MentoringStepBlock(
-        StudioEditableXBlockMixin, StudioContainerWithNestedXBlocksMixin, XBlockWithPreviewMixin,
-        EnumerableChildMixin, StepParentMixin, StudentViewUserStateMixin, XBlock
+    StudioEditableXBlockMixin, StudioContainerWithNestedXBlocksMixin, XBlockWithPreviewMixin,
+    EnumerableChildMixin, StepParentMixin, StudentViewUserStateResultsTransformerMixin,
+    StudentViewUserStateMixin, XBlock,
 ):
     """
     An XBlock for a step.
@@ -78,6 +80,7 @@ class MentoringStepBlock(
     CAPTION = _(u"Step")
     STUDIO_LABEL = _(u"Mentoring Step")
     CATEGORY = 'sb-step'
+    USER_STATE_FIELDS = ['student_results']
 
     # Settings
     display_name = String(
@@ -279,6 +282,7 @@ class MentoringStepBlock(
                 components.append(child.student_view_data(context))
 
         return {
+            'block_id': unicode(self.scope_ids.usage_id),
             'type': self.CATEGORY,
             'title': self.display_name_with_default,
             'show_title': self.show_title,

--- a/problem_builder/step_review.py
+++ b/problem_builder/step_review.py
@@ -111,6 +111,7 @@ class ConditionalMessageBlock(
 
     def student_view_data(self, context=None):
         return {
+            'block_id': unicode(self.scope_ids.usage_id),
             'type': self.CATEGORY,
             'content': self.content,
             'score_condition': self.score_condition,
@@ -160,9 +161,8 @@ class ScoreSummaryBlock(XBlockWithTranslationServiceMixin, XBlockWithPreviewMixi
         return Fragment(html)
 
     def student_view_data(self, context=None):
-        context = context or {}
-
         return {
+            'block_id': unicode(self.scope_ids.usage_id),
             'type': self.CATEGORY,
         }
 
@@ -216,6 +216,7 @@ class PerQuestionFeedbackBlock(XBlockWithTranslationServiceMixin, XBlockWithPrev
 
     def student_view_data(self, context=None):
         return {
+            'block_id': unicode(self.scope_ids.usage_id),
             'type': self.CATEGORY,
         }
 
@@ -312,6 +313,7 @@ class ReviewStepBlock(
                 components.append(child.student_view_data(context))
 
         return {
+            'block_id': unicode(self.scope_ids.usage_id),
             'type': self.CATEGORY,
             'title': self.display_name,
             'components': components,

--- a/problem_builder/tests/unit/test_answer_mixin.py
+++ b/problem_builder/tests/unit/test_answer_mixin.py
@@ -78,11 +78,7 @@ class TestAnswerMixin(unittest.TestCase):
         student_view_user_state = answer_mixin.build_user_state_data()
 
         expected_user_state_data = {
-            "answer_data": {
-                "student_input": existing_model.student_input,
-                "created_on": existing_model.created_on,
-                "modified_on": existing_model.modified_on,
-            }
+            "student_input": existing_model.student_input,
         }
         self.assertEqual(student_view_user_state, expected_user_state_data)
 
@@ -103,10 +99,6 @@ class TestAnswerMixin(unittest.TestCase):
         parsed_student_state = json.loads(student_view_user_state.body)
 
         expected_user_state_data = {
-            "answer_data": {
-                "student_input": existing_model.student_input,
-                "created_on": existing_model.created_on.isoformat(),
-                "modified_on": existing_model.modified_on.isoformat(),
-            }
+            "student_input": existing_model.student_input,
         }
         self.assertEqual(parsed_student_state, expected_user_state_data)

--- a/problem_builder/tests/unit/test_problem_builder.py
+++ b/problem_builder/tests/unit/test_problem_builder.py
@@ -24,7 +24,7 @@ class TestMRQBlock(BlockWithChildrenTestMixin, unittest.TestCase):
 
         self.assertListEqual(
             block.student_view_data().keys(),
-            ['hide_results', 'tips', 'weight', 'title', 'question', 'message', 'type', 'id', 'choices'])
+            ['hide_results', 'tips', 'block_id', 'weight', 'title', 'question', 'message', 'type', 'id', 'choices'])
 
 
 @ddt.ddt
@@ -141,13 +141,14 @@ class TestMentoringBlock(BlockWithChildrenTestMixin, unittest.TestCase):
         children_by_id = {child.block_id: child for child in children}
         block_data = {'children': children}
         block_data.update(shared_data)
-        block = MentoringBlock(Mock(), DictFieldData(block_data), Mock())
+        block = MentoringBlock(Mock(usage_id=1), DictFieldData(block_data), Mock(usage_id=1))
         block.runtime = Mock(
             get_block=lambda block: children_by_id[block.block_id],
             load_block_type=lambda block: Mock,
             id_reader=Mock(get_definition_id=lambda block: block, get_block_type=lambda block: block),
         )
         expected = {
+            'block_id': '1',
             'components': [
                 'child_a_json',
             ],

--- a/problem_builder/tests/unit/test_step_builder.py
+++ b/problem_builder/tests/unit/test_step_builder.py
@@ -11,7 +11,6 @@ from .utils import BlockWithChildrenTestMixin
 
 
 class TestMentoringBlock(BlockWithChildrenTestMixin, unittest.TestCase):
-
     def test_student_view_data(self):
         blocks_by_id = {}
 
@@ -90,6 +89,7 @@ class TestMentoringBlock(BlockWithChildrenTestMixin, unittest.TestCase):
         make_block(ConditionalMessageBlock, conditional_message_data, for_parent=review_step)
 
         expected = {
+            'block_id': u'1',
             'title': step_builder_data['display_name'],
             'show_title': step_builder_data['show_title'],
             'weight': step_builder_data['weight'],
@@ -97,6 +97,7 @@ class TestMentoringBlock(BlockWithChildrenTestMixin, unittest.TestCase):
             'extended_feedback': step_builder_data['extended_feedback'],
             'components': [
                 {
+                    'block_id': '2',
                     'type': 'sb-step',
                     'title': step_data['display_name'],
                     'show_title': step_data['show_title'],
@@ -105,13 +106,16 @@ class TestMentoringBlock(BlockWithChildrenTestMixin, unittest.TestCase):
                     'components': ['child_a_json'],
                 },
                 {
+                    'block_id': '3',
                     'type': 'sb-review-step',
                     'title': review_step_data['display_name'],
                     'components': [
                         {
+                            'block_id': '4',
                             'type': 'sb-review-score',
                         },
                         {
+                            'block_id': '5',
                             'type': 'sb-conditional-message',
                             'content': conditional_message_data['content'],
                             'score_condition': conditional_message_data['score_condition'],

--- a/problem_builder/tip.py
+++ b/problem_builder/tip.py
@@ -95,6 +95,12 @@ class TipBlock(StudioEditableXBlockMixin, XBlockWithTranslationServiceMixin, XBl
         })
         return Fragment(html)
 
+    def student_view_data(self, context=None):
+        return {
+            'content': self.content,
+            'for_choices': self.values,
+        }
+
     def student_view(self, context=None):
         """ Normal view of this XBlock, identical to mentoring_view """
         return self.mentoring_view(context)

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='2.7.2',
+    version='2.7.3',
     description='XBlock - Problem Builder',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
This PR adds a way to allow developers to manually control what fields eventually appear in `student_view_user_state` via `build_user_state_data` by specifying attributes on XBlocks that inherit from `StudentViewUserStateMixin`

**JIRA tickets**: [OC-2958](https://tasks.opencraft.com/browse/OC-2958)

**Dependencies**: None

**Merge deadline**: None

**Testing instructions**:

**student_view_user_state**
1. When viewing an XBlock's `student_view_user_state` (e.g. http://localhost:8000/courses/<course_id>/xblock/<xblock_usage_id>/handler/student_view_user_state), modify fields by adding field names to the block's `USER_STATE_FIELDS` or field name -> function to `USER_STATE_TRANSFORMS`
2. See them appear in the JSON output

**student_view_data**
1. When viewing a course's `student_view_data`, notice that `block_id` is included.

**Reviewers**
- [ ] @bradenmacdonald 