### PR TITLE
Support for MRQ, user ID and user e-mail in Instructor Tool

### DIFF
--- a/problem_builder/instructor_tool.py
+++ b/problem_builder/instructor_tool.py
@@ -135,6 +135,7 @@ class InstructorToolBlock(XBlock):
             return Fragment(u'<p>This interface can only be used by course staff.</p>')
         block_choices = {
             _('Multiple Choice Question'): 'MCQBlock',
+            _('Multiple Response Question'): 'MRQBlock',
             _('Rating Question'): 'RatingBlock',
             _('Long Answer'): 'AnswerBlock',
         }

--- a/problem_builder/public/js/instructor_tool.js
+++ b/problem_builder/public/js/instructor_tool.js
@@ -251,7 +251,7 @@ function InstructorToolBlock(runtime, element) {
     }
 
     // Block types with answers we can export
-    var questionBlockTypes = ['pb-mcq', 'pb-rating', 'pb-answer'];
+    var questionBlockTypes = ['pb-mcq', 'pb-mrq', 'pb-rating', 'pb-answer'];
 
     // Fetch this course's blocks from the REST API, and add them to the
     // list of blocks in the Section/Question drop-down list.

--- a/problem_builder/tasks.py
+++ b/problem_builder/tasks.py
@@ -12,6 +12,7 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
 from .mcq import MCQBlock, RatingBlock
+from .mrq import MRQBlock
 from problem_builder.answer import AnswerBlock
 from .questionnaire import QuestionnaireAbstractBlock
 from .sub_api import sub_api
@@ -22,7 +23,7 @@ logger = get_task_logger(__name__)
 @task()
 def export_data(course_id, source_block_id_str, block_types, user_ids, match_string):
     """
-    Exports student answers to all MCQ questions to a CSV file.
+    Exports student answers to all supported questions to a CSV file.
     """
     start_timestamp = time.time()
 
@@ -34,7 +35,7 @@ def export_data(course_id, source_block_id_str, block_types, user_ids, match_str
         raise ValueError("Could not find the specified Block ID.")
     course_key_str = unicode(course_key)
 
-    type_map = {cls.__name__: cls for cls in [MCQBlock, RatingBlock, AnswerBlock]}
+    type_map = {cls.__name__: cls for cls in [MCQBlock, MRQBlock, RatingBlock, AnswerBlock]}
 
     if not block_types:
         block_types = tuple(type_map.values())

--- a/problem_builder/tasks.py
+++ b/problem_builder/tasks.py
@@ -61,7 +61,9 @@ def export_data(course_id, source_block_id_str, block_types, user_ids, match_str
 
     # Define the header row of our CSV:
     rows = []
-    rows.append(["Section", "Subsection", "Unit", "Type", "Question", "Answer", "Username"])
+    rows.append(
+        ["Section", "Subsection", "Unit", "Type", "Question", "Answer", "Username", "User ID", "User E-mail"]
+    )
 
     # Collect results for each block in blocks_to_include
     for block in blocks_to_include:
@@ -109,17 +111,27 @@ def _extract_data(course_key_str, block, user_id, match_string):
     # - Get all of the most recent student submissions for this block:
     submissions = _get_submissions(course_key_str, block, user_id)
 
-    # - For each submission, look up student's username and answer:
+    # - For each submission, look up student's username, email and answer:
     answer_cache = {}
     for submission in submissions:
-        username = _get_username(submission, user_id)
+        username, _user_id, user_email = _get_user_info(submission, user_id)
         answer = _get_answer(block, submission, answer_cache)
 
         # Short-circuit if answer does not match search criteria
         if not match_string.lower() in answer.lower():
             continue
 
-        rows.append([section_name, subsection_name, unit_name, block_type, block_question, answer, username])
+        rows.append([
+            section_name,
+            subsection_name,
+            unit_name,
+            block_type,
+            block_question,
+            answer,
+            username,
+            _user_id,
+            user_email
+        ])
 
     return rows
 
@@ -176,19 +188,19 @@ def _get_submissions(course_key_str, block, user_id):
         return sub_api.get_submissions(student_dict, limit=1)
 
 
-def _get_username(submission, user_id):
+def _get_user_info(submission, user_id):
     """
-    Return username of student who provided `submission`.
+    Return a (username, user id, user email) tuple for the student who provided `submission`.
 
-    If the anonymous id of the submission can't be resolved into a username, the anonymous
-    id is returned.
+    If the anonymous ID of the submission can't be resolved into a user,
+    (student ID, 'N/A', 'N/A') is returned
     """
     # If the student ID key doesn't exist, we're dealing with a single student and know the ID already.
     student_id = submission.get('student_id', user_id)
     user = user_by_anonymous_id(student_id)
     if user is None:
-        return student_id
-    return user.username
+        return (student_id, 'N/A', 'N/A')
+    return (user.username, user.id, user.email)
 
 
 def _get_answer(block, submission, answer_cache):

--- a/problem_builder/tests/unit/test_instructor_tool.py
+++ b/problem_builder/tests/unit/test_instructor_tool.py
@@ -48,6 +48,7 @@ class TestInstructorToolBlock(unittest.TestCase):
         """
         block_choices = {
             'Multiple Choice Question': 'MCQBlock',
+            'Multiple Response Question': 'MRQBlock',
             'Rating Question': 'RatingBlock',
             'Long Answer': 'AnswerBlock',
         }


### PR DESCRIPTION
This extends the Instructor Tool module to:
* Add support for MRQ in the HTML and CSV reports.
* Add user ID and user email columns to the CSV report.

**JIRA ticket**:  [OC-2997](https://tasks.opencraft.com/browse/OC-2997)

**Testing instructions**:
1. Add a couple of MRQ in a problem builder xblock
2. Submit answer(s) with a few users
3. Verify in the Instructor Tool that MRQs are filterable in the dropdown 
4. Make sure MRQs are displayed in the HTML table and included in the CSV export
5. Make sure user IDs and user emails are included in the CSV export but not in the HTML table

**Considerations**:
When choosing a MCQ filter in the Instructor Tool, also Rating questions (a subclass of MCQ) are listed. I'm assuming this is desired behaviour because technically ratings are also MCQ?
