### PR TITLE
Fix Instructor Tool in Apros

### DIFF
--- a/problem_builder/public/js/instructor_tool.js
+++ b/problem_builder/public/js/instructor_tool.js
@@ -288,7 +288,7 @@ function InstructorToolBlock(runtime, element) {
         // Returns the <option> element so that it can be enabled later,
         // if it's found to have a descendant that is enabled.
         var appendBlock = function(block) {
-            var blockId = block.id.split('+block@').pop(),
+            var blockId = block.id,
                 padding = Array(2*block.depth).join('&nbsp;'),
                 disabled = (block.enabled ? undefined : 'disabled'),
                 labelAttr,

--- a/problem_builder/tasks.py
+++ b/problem_builder/tasks.py
@@ -6,7 +6,8 @@ import time
 from celery.task import task
 from celery.utils.log import get_task_logger
 from lms.djangoapps.instructor_task.models import ReportStore
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey, UsageKey
 from student.models import user_by_anonymous_id
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
@@ -29,11 +30,12 @@ def export_data(course_id, source_block_id_str, block_types, user_ids, match_str
     logger.debug("Beginning data export")
     try:
         course_key = CourseKey.from_string(course_id)
-        src_block = modulestore().get_items(course_key, qualifiers={'name': source_block_id_str}, depth=0)[0]
-    except IndexError:
+        usage_key = UsageKey.from_string(source_block_id_str)
+    except InvalidKeyError:
         raise ValueError("Could not find the specified Block ID.")
-    course_key_str = unicode(course_key)
 
+    src_block = modulestore().get_item(usage_key)
+    course_key_str = unicode(course_key)
     type_map = {cls.__name__: cls for cls in [MCQBlock, RatingBlock, AnswerBlock]}
 
     if not block_types:


### PR DESCRIPTION
This fixes the Instructor Tool in Apros which was raising a `Could not find the specified block ID` error.

1. It removes a block ID manipulation from the JS code that was causing bugs in the backs for all IDs without a `block@` substring, like the Apros' ones (e.g. `i4x://132re3fe2oif...`).
2. It looks up the block by UsageKey rather than a selector, making it work for all IDs.

**JIRA ticket**: [OC-2998](https://tasks.opencraft.com/browse/OC-2998)

**Testing instructions**:
1. Check that the Instructor Tool in Apros exports HTML and CSV reports.
2. Check that the source block filter works correctly.
3. Check that the Instructor Tool still works with the regular devstack.

