### PR TITLE
Student view data with display names

### DIFF
--- a/doc/Native APIs.md
+++ b/doc/Native APIs.md
@@ -26,6 +26,7 @@ Problem Builder (`problem-builder`)
 ### `student_view_data`
 
 - `block_id`: (string) The XBlock's usage ID.
+- `display_name`: (string) The XBlock's display name.
 - `max_attempts`: (integer) Max number of allowed attempts.
 - `extended_feedback`: (boolean) `true` if extended feedback is enabled for this
   block.
@@ -103,6 +104,7 @@ Step Builder (`step-builder`)
 ### `student_view_data`
 
 - `block_id`: (string) The XBlock's usage ID.
+- `display_name`: (string) The XBlock's display name.
 - `title`: (string) The display name of the component.
 - `show_title`: (boolean) `true` if the title should be displayed.
 - `weight`: (float) The weight of the problem.
@@ -164,6 +166,7 @@ Mentoring Step (`sb-step`)
 ### `student_view_data`
 
 - `block_id`: (string) The XBlock's usage ID.
+- `display_name`: (string) The XBlock's display name.
 - `type`: (string) Always equals `"sb-step"` for Mentoring Step components.
 - `title`: (string) Step component's display name.
 - `show_title`: (boolean) `true` if the title should be displayed.
@@ -187,6 +190,7 @@ Review Step (`sb-review-step`)
 ### `student_view_data`
 
 - `block_id`: (string) The XBlock's usage ID.
+- `display_name`: (string) The XBlock's display name.
 - `type`: (string) Always equals `"sb-review-step`" for Review Step components.
 - `title`: (string) Display name of the component.
 - `components`: (array) A list of `student_view_data` output of all immediate
@@ -201,6 +205,7 @@ Conditional Message component is always child of a Review Step component.
 ### `student_view_data`
 
 - `block_id`: (string) The XBlock's usage ID.
+- `display_name`: (string) The XBlock's display name.
 - `type`: (string) Always equals `"sb-conditional-message"` for Conditional
   Message components.
 - `content`: (string) Content of the message. May contain HTML.
@@ -214,6 +219,7 @@ Score Summary (`sb-review-score`)
 ### `student_view_data`
 
 - `block_id`: (string) The XBlock's usage ID.
+- `display_name`: (string) The XBlock's display name.
 - `type`: (string) Always equals `"sb-review-score"` for Score Summary
   components.
 
@@ -223,6 +229,7 @@ Per-Question Feedback (`sb-review-per-question-feedback`)
 ### `student_view_data`
 
 - `block_id`: (string) The XBlock's usage ID.
+- `display_name`: (string) The XBlock's display name.
 - `type`: (string) Always equals `"sb-review-per-question-feedback"` for Score
   Summary components.
 
@@ -232,6 +239,7 @@ Long Answer (`pb-answer`)
 ### `student_view_data`
 
 - `block_id`: (string) The XBlock's usage ID.
+- `display_name`: (string) The XBlock's display name.
 - `type`: (string) Always equals `"pb-answer"` for Long Answer components.
 - `id`: (string) Unique ID (name) of the component.
 - `weight`: (float) The weight of this component.
@@ -269,6 +277,7 @@ Multiple Choice Question (`pb-mcq`)
 ### `student_view_data`
 
 - `block_id`: (string) The XBlock's usage ID.
+- `display_name`: (string) The XBlock's display name.
 - `type`: (string) Always equals `"pb-mcq"` for MCQ components.
 - `id`: (string) Unique ID (name) of the component.
 - `question`: (string) The content of the question.
@@ -320,6 +329,7 @@ Rating Question (`pb-rating`)
 ### `student_view_data`
 
 - `block_id`: (string) The XBlock's usage ID.
+- `display_name`: (string) The XBlock's display name.
 Identical to [MCQ questions](#multiple-choice-question-pb-mcq) except that the
 `type` field always equals `"pb-rating"`.
 
@@ -342,6 +352,7 @@ Multiple Response Question (`pb-mrq`)
 ### `student_view_data`
 
 - `block_id`: (string) The XBlock's usage ID.
+- `display_name`: (string) The XBlock's display name.
 - `type`: (string) Always equals `"pb-mrq"` for Multiple Response Question
   components.
 - `id`: (string) Unique ID (name) of the component.
@@ -399,6 +410,7 @@ Ranged Value Slider (`pb-slider`)
 ### `student_view_data`
 
 - `block_id`: (string) The XBlock's usage ID.
+- `display_name`: (string) The XBlock's display name.
 - `type`: (string) Always equals `"pb-slider"` for Ranged Value Slider
   components.
 - `id`: (string) Unique ID (name) of the component.
@@ -431,6 +443,7 @@ Completion (`pb-completion`)
 ### `student_view_data`
 
 - `block_id`: (string) The XBlock's usage ID.
+- `display_name`: (string) The XBlock's display name.
 - `type`: (string) Always equals `"pb-completion"` for Completion components.
 - `id`: (string) Unique ID (name) of the component.
 - `title`: (string) Display name of the problem.
@@ -463,6 +476,7 @@ Plot (`sb-plot`)
 ### `student_view_data`
 
 - `block_id`: (string) The XBlock's usage ID.
+- `display_name`: (string) The XBlock's display name.
 - `type`: (string) Always equals `"sb-plot"` for Plot components.
 - `title`: (string) Display name of the component.
 - `q1_label`: (string) Quadrant I label.

--- a/problem_builder/answer.py
+++ b/problem_builder/answer.py
@@ -267,6 +267,7 @@ class AnswerBlock(SubmittingXBlockMixin, AnswerMixin, QuestionMixin, StudioEdita
         return {
             'id': self.name,
             'block_id': unicode(self.scope_ids.usage_id),
+            'display_name': self.display_name,
             'type': self.CATEGORY,
             'weight': self.weight,
             'question': self.question,

--- a/problem_builder/choice.py
+++ b/problem_builder/choice.py
@@ -77,7 +77,7 @@ class ChoiceBlock(
         # display_name_with_default gives out correctness - not adding it here
         return {
             'block_id': unicode(self.scope_ids.usage_id),
-            'display_name': self._(u"Choice ({content})").format(content=self.content)
+            'display_name': self._(u"Choice ({content})").format(content=self.content),
             'value': self.value,
             'content': self.content,
         }

--- a/problem_builder/choice.py
+++ b/problem_builder/choice.py
@@ -74,8 +74,10 @@ class ChoiceBlock(
         Returns a JSON representation of the student_view of this XBlock,
         retrievable from the Course Block API.
         """
+        # display_name_with_default gives out correctness - not adding it here
         return {
             'block_id': unicode(self.scope_ids.usage_id),
+            'display_name': self._(u"Choice ({content})").format(content=self.content)
             'value': self.value,
             'content': self.content,
         }

--- a/problem_builder/completion.py
+++ b/problem_builder/completion.py
@@ -116,6 +116,7 @@ class CompletionBlock(
         return {
             'id': self.name,
             'block_id': unicode(self.scope_ids.usage_id),
+            'display_name': self.display_name_with_default,
             'type': self.CATEGORY,
             'question': self.question,
             'answer': self.answer,

--- a/problem_builder/mcq.py
+++ b/problem_builder/mcq.py
@@ -177,6 +177,7 @@ class MCQBlock(SubmittingXBlockMixin, StudentViewUserStateMixin, QuestionnaireAb
         return {
             'id': self.name,
             'block_id': unicode(self.scope_ids.usage_id),
+            'display_name': self.display_name_with_default,
             'type': self.CATEGORY,
             'question': self.question,
             'message': self.message,

--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -923,6 +923,7 @@ class MentoringBlock(
                 components.append(block.student_view_data())
         return {
             'block_id': unicode(self.scope_ids.usage_id),
+            'display_name': self.display_name,
             'max_attempts': self.max_attempts,
             'extended_feedback': self.extended_feedback,
             'feedback_label': self.feedback_label,
@@ -1272,6 +1273,7 @@ class MentoringWithExplicitStepsBlock(BaseMentoringBlock, StudioContainerWithNes
         return {
             'title': self.display_name,
             'block_id': unicode(self.scope_ids.usage_id),
+            'display_name': self.display_name,
             'show_title': self.show_title,
             'weight': self.weight,
             'extended_feedback': self.extended_feedback,

--- a/problem_builder/mrq.py
+++ b/problem_builder/mrq.py
@@ -207,6 +207,7 @@ class MRQBlock(SubmittingXBlockMixin, StudentViewUserStateMixin, QuestionnaireAb
         return {
             'id': self.name,
             'block_id': unicode(self.scope_ids.usage_id),
+            'display_name': self.display_name,
             'title': self.display_name,
             'type': self.CATEGORY,
             'weight': self.weight,

--- a/problem_builder/plot.py
+++ b/problem_builder/plot.py
@@ -362,6 +362,7 @@ class PlotBlock(
         retrievable from the Course XBlock API.
         """
         return {
+            'display_name': self.display_name,
             'type': self.CATEGORY,
             'title': self.display_name,
             'q1_label': self.q1_label,

--- a/problem_builder/slider.py
+++ b/problem_builder/slider.py
@@ -128,6 +128,7 @@ class SliderBlock(
         return {
             'id': self.name,
             'block_id': unicode(self.scope_ids.usage_id),
+            'display_name': self.display_name_with_default,
             'type': self.CATEGORY,
             'question': self.question,
             'min_label': self.min_label,

--- a/problem_builder/step.py
+++ b/problem_builder/step.py
@@ -283,6 +283,7 @@ class MentoringStepBlock(
 
         return {
             'block_id': unicode(self.scope_ids.usage_id),
+            'display_name': self.display_name_with_default,
             'type': self.CATEGORY,
             'title': self.display_name_with_default,
             'show_title': self.show_title,

--- a/problem_builder/step_review.py
+++ b/problem_builder/step_review.py
@@ -112,6 +112,7 @@ class ConditionalMessageBlock(
     def student_view_data(self, context=None):
         return {
             'block_id': unicode(self.scope_ids.usage_id),
+            'display_name': self.display_name_with_default,
             'type': self.CATEGORY,
             'content': self.content,
             'score_condition': self.score_condition,
@@ -163,6 +164,7 @@ class ScoreSummaryBlock(XBlockWithTranslationServiceMixin, XBlockWithPreviewMixi
     def student_view_data(self, context=None):
         return {
             'block_id': unicode(self.scope_ids.usage_id),
+            'display_name': self.display_name_with_default,
             'type': self.CATEGORY,
         }
 
@@ -217,6 +219,7 @@ class PerQuestionFeedbackBlock(XBlockWithTranslationServiceMixin, XBlockWithPrev
     def student_view_data(self, context=None):
         return {
             'block_id': unicode(self.scope_ids.usage_id),
+            'display_name': self.display_name_with_default,
             'type': self.CATEGORY,
         }
 
@@ -314,6 +317,7 @@ class ReviewStepBlock(
 
         return {
             'block_id': unicode(self.scope_ids.usage_id),
+            'display_name': self.display_name,
             'type': self.CATEGORY,
             'title': self.display_name,
             'components': components,

--- a/problem_builder/tests/unit/test_problem_builder.py
+++ b/problem_builder/tests/unit/test_problem_builder.py
@@ -22,9 +22,13 @@ class TestMRQBlock(BlockWithChildrenTestMixin, unittest.TestCase):
         """
         block = MRQBlock(Mock(), DictFieldData({}), Mock())
 
-        self.assertListEqual(
+        self.assertItemsEqual(
             block.student_view_data().keys(),
-            ['hide_results', 'tips', 'block_id', 'weight', 'title', 'question', 'message', 'type', 'id', 'choices'])
+            [
+                'hide_results', 'tips', 'block_id', 'display_name',
+                'weight', 'title', 'question', 'message', 'type', 'id', 'choices'
+            ]
+        )
 
 
 @ddt.ddt
@@ -139,7 +143,8 @@ class TestMentoringBlock(BlockWithChildrenTestMixin, unittest.TestCase):
         }
         children = get_mock_components()
         children_by_id = {child.block_id: child for child in children}
-        block_data = {'children': children}
+        display_name = "I'm problem builder"
+        block_data = {'display_name': display_name, 'children': children}
         block_data.update(shared_data)
         block = MentoringBlock(Mock(usage_id=1), DictFieldData(block_data), Mock(usage_id=1))
         block.runtime = Mock(
@@ -149,6 +154,7 @@ class TestMentoringBlock(BlockWithChildrenTestMixin, unittest.TestCase):
         )
         expected = {
             'block_id': '1',
+            'display_name': display_name,
             'components': [
                 'child_a_json',
             ],

--- a/problem_builder/tests/unit/test_step_builder.py
+++ b/problem_builder/tests/unit/test_step_builder.py
@@ -14,9 +14,14 @@ class TestMentoringBlock(BlockWithChildrenTestMixin, unittest.TestCase):
     def test_student_view_data(self):
         blocks_by_id = {}
 
+        services_mocks = {
+            "i18n": Mock(ugettext=lambda string: string)
+        }
+
         mock_runtime = Mock(
             get_block=lambda block_id: blocks_by_id[block_id],
             load_block_type=lambda block: block.__class__,
+            service=lambda _, service_id: services_mocks.get(service_id),
             id_reader=Mock(
                 get_definition_id=lambda block_id: block_id,
                 get_block_type=lambda block_id: blocks_by_id[block_id],
@@ -90,6 +95,7 @@ class TestMentoringBlock(BlockWithChildrenTestMixin, unittest.TestCase):
 
         expected = {
             'block_id': u'1',
+            'display_name': step_builder_data['display_name'],
             'title': step_builder_data['display_name'],
             'show_title': step_builder_data['show_title'],
             'weight': step_builder_data['weight'],
@@ -99,6 +105,7 @@ class TestMentoringBlock(BlockWithChildrenTestMixin, unittest.TestCase):
                 {
                     'block_id': '2',
                     'type': 'sb-step',
+                    'display_name': step_data['display_name'],
                     'title': step_data['display_name'],
                     'show_title': step_data['show_title'],
                     'next_button_label': step_data['next_button_label'],
@@ -108,14 +115,17 @@ class TestMentoringBlock(BlockWithChildrenTestMixin, unittest.TestCase):
                 {
                     'block_id': '3',
                     'type': 'sb-review-step',
+                    'display_name': review_step_data['display_name'],
                     'title': review_step_data['display_name'],
                     'components': [
                         {
                             'block_id': '4',
+                            'display_name': "Score Summary",
                             'type': 'sb-review-score',
                         },
                         {
                             'block_id': '5',
+                            'display_name': "Conditional Message",
                             'type': 'sb-conditional-message',
                             'content': conditional_message_data['content'],
                             'score_condition': conditional_message_data['score_condition'],

--- a/problem_builder/tip.py
+++ b/problem_builder/tip.py
@@ -97,6 +97,7 @@ class TipBlock(StudioEditableXBlockMixin, XBlockWithTranslationServiceMixin, XBl
 
     def student_view_data(self, context=None):
         return {
+            'display_name': self.display_name_with_default,
             'content': self.content,
             'for_choices': self.values,
         }

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='2.7.4',
+    version='2.7.5',
     description='XBlock - Problem Builder',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
**Description:** This PR adds `display_name` field to `student_view_data`.

**Author concerns:**

1. `student_view_data` is added as a method individually to each XBlock that needs it - there are no common base method - not fixing this due to being out of scope and lack of time.
1. `student_view_data` test coverage is quite superfluous - just a handful of blocks are checked - not fixing this due to being out of scope and lack of time.
1. Some XBlocks already provided `display_name` field via `title` key - not changing `title` as it is likely used by the clients and still adding `display_name` to provide a common denominator to all XBlocks.

**Merge deadline:** Monday, 2017-09-18.

**Testing:**

0. Install this version
1. Create a course with Problem builders (or just import from OpenCraft demo courses repo)
2. Read from LMS course content API: http://localhost:8000/api/courses/v1/blocks/block-v1%3AOrg1%2BPB1%2BT1%2Btype%40problem-builder%2Bblock%40979b4a84326941309413f3347e5b5d75/?depth=all&fields=student_view_data&username=staff&student_view_data=all
3. Make sure that `student_view_data` field contains `display_name` for all XBlocks that have it defined.
4. Make sure that documentation (NativeAPI.md) is updated for all XBlock that have display_name added to student_view_data