### PR TITLE
Fix student_value field default

### DIFF
--- a/problem_builder/completion.py
+++ b/problem_builder/completion.py
@@ -82,7 +82,7 @@ class CompletionBlock(
     student_value = Boolean(
         help=_("Records student's answer."),
         scope=Scope.user_state,
-        default=None,
+        default=False,
     )
 
     editable_fields = ('display_name', 'show_title', 'question', 'answer')

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='2.8.0',
+    version='2.8.1',
     description='XBlock - Problem Builder',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
The `student_value` field of CompletionBlock was configured to default to `None`, which just gets coerced to `False` immediately upon initialization after throwing a `ModifyingEnforceTypeWarning`.  Setting the default directly to `False` bypasses this extra work and helps cut down on the number of warnings thrown in `edx-platform` test runs.

If the intent was for there to actually be no default value, the `default` keyword can be omitted, but that would be a change from the current behavior.