### PR TITLE
Adding support for notifying interactions to "mentoring" problem builder

### DIFF
--- a/problem_builder/public/js/mentoring.js
+++ b/problem_builder/public/js/mentoring.js
@@ -25,7 +25,9 @@ function MentoringBlock(runtime, element) {
         step: step,
         steps: steps,
         publish_event: publish_event,
-        data: data
+        data: data,
+        notify: notify,
+        notifyInteraction: notifyInteraction
     };
 
     function publish_event(data) {
@@ -109,6 +111,29 @@ function MentoringBlock(runtime, element) {
                 return child;
             }
         }
+    }
+
+    function notify(name, data) {
+        // Notification interface does not exist in the workbench.
+        if (runtime.notify) {
+            runtime.notify(name, data);
+        }
+    }
+
+    function notifyInteraction(num_attempts, max_attempts, score) {
+        // Tell XBlock runtime that an interaction with this XBlock happened, submitting
+        // current and max attempts and current score. Runtime is free to react to this event as necessary.
+        // This event is not used in this XBlock, but removing it might break some integrations with third party
+        // software
+        var interactionData = {
+            "attempts_count": num_attempts,
+            "attempts_max": max_attempts || "unlimited",
+            "score": score
+        };
+        notify("xblock.interaction", interactionData);
+
+        var xblockBackendEventData = $.extend({}, interactionData, {event_type: 'xblock.interaction'});
+        publish_event(xblockBackendEventData);
     }
 
     ProblemBuilderUtil.transformClarifications(element);

--- a/problem_builder/public/js/mentoring_assessment_view.js
+++ b/problem_builder/public/js/mentoring_assessment_view.js
@@ -36,7 +36,7 @@ function MentoringAssessmentView(runtime, element, mentoring) {
     }
 
     function renderGrade() {
-        notify('navigation', {state: 'unlock'})
+        mentoring.notify('navigation', {state: 'unlock'});
         var data = $('.grade', element).data();
         data.enable_extended = (no_more_attempts() && data.extended_feedback);
         _.extend(data, {
@@ -92,7 +92,7 @@ function MentoringAssessmentView(runtime, element, mentoring) {
             return;
 
         active_child = -1;
-        notify('navigation', {state: 'lock'})
+        mentoring.notify('navigation', {state: 'lock'})
         displayNextChild();
         tryAgainDOM.hide();
         submitDOM.show();
@@ -110,7 +110,7 @@ function MentoringAssessmentView(runtime, element, mentoring) {
     }
 
     function initXBlockView() {
-        notify('navigation', {state: 'lock'})
+        mentoring.notify('navigation', {state: 'lock'})
         submitDOM = $(element).find('.submit .input-main');
         nextDOM = $(element).find('.submit .input-next');
         reviewDOM = $(element).find('.submit .input-review');
@@ -155,13 +155,6 @@ function MentoringAssessmentView(runtime, element, mentoring) {
 
     function isDone() {
         return (active_child == mentoring.steps.length);
-    }
-
-    function notify(name, data){
-        // Notification interface does not exist in the workbench.
-        if (runtime.notify) {
-            runtime.notify(name, data)
-        }
     }
 
     function reviewJump(event) {
@@ -305,6 +298,8 @@ function MentoringAssessmentView(runtime, element, mentoring) {
         handleResults(response);
         // Update grade information
         $('.grade').data(response);
+
+        mentoring.notifyInteraction(response.num_attempts, response.max_attempts, response.score);
     }
 
 

--- a/problem_builder/public/js/mentoring_standard_view.js
+++ b/problem_builder/public/js/mentoring_standard_view.js
@@ -4,7 +4,7 @@ function MentoringStandardView(runtime, element, mentoring) {
 
     var callIfExists = mentoring.callIfExists;
 
-    function handleSubmitResults(response, disable_submit) {
+    function handleSubmitResults(response, disable_submit, trigger_interaction) {
         messagesDOM.empty().hide();
 
         var hide_results = response.message === undefined;
@@ -25,6 +25,10 @@ function MentoringStandardView(runtime, element, mentoring) {
 
         $('.attempts', element).data('max_attempts', response.max_attempts);
         $('.attempts', element).data('num_attempts', response.num_attempts);
+
+        if (trigger_interaction) {
+            mentoring.notifyInteraction(response.num_attempts, response.max_attempts, "N/A");
+        }
         mentoring.renderAttempts();
 
         if (!hide_results) {
@@ -66,7 +70,7 @@ function MentoringStandardView(runtime, element, mentoring) {
         }
     }
 
-    function calculate_results(handler_name, disable_submit) {
+    function calculate_results(handler_name, disable_submit, trigger_interaction) {
         var data = {};
         var children = mentoring.children;
         for (var i = 0; i < children.length; i++) {
@@ -80,16 +84,16 @@ function MentoringStandardView(runtime, element, mentoring) {
             submitXHR.abort();
         }
         submitXHR = $.post(handlerUrl, JSON.stringify(data))
-            .success(function(response) { handleSubmitResults(response, disable_submit); })
+            .success(function(response) { handleSubmitResults(response, disable_submit, trigger_interaction); })
             .error(function(jqXHR, textStatus, errorThrown) { handleSubmitError(jqXHR, textStatus, errorThrown, disable_submit); });
     }
 
     function get_results(){
-        calculate_results('get_results', false);
+        calculate_results('get_results', false, false);
     }
 
     function submit() {
-        calculate_results('submit', true);
+        calculate_results('submit', true, true);
     }
 
     function clearResults() {

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='2.8.0',
+    version='2.8.1',
     description='XBlock - Problem Builder',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
**Description:** This PR makes use of [Apros API](https://github.com/mckinseyacademy/mcka_apros/pull/1834) to submit interactions to SCORM shell from outdated "mentoring" problem builder.

Mechanism employed s pretty generic (submitting JS XBlock event) and not tied to Apros.

**Author concerns:** support for "assessment" mode is reduced in latest version of problem builder - it is not possible to create an atssessment mentoring block anymore. In this PR, assessment mode is also affected, but it is not possible to test the changes without existing course with "assessment" mode PR. Unfortunately, I don't have one, so I was unable to test assessment mmode

**Dependecies:** Self-contained, but effect can be only seen by applying https://github.com/mckinseyacademy/mcka_apros/pull/1834

**Testing instructions:**
0. Create a course with Mentoring Problem Builder. Make sure some questions are graded to test submitting correct grade, and number of attempts is limited.
1. In Apros complete the problem and go to review step
1.1. Expected result: [this line](https://github.com/mckinseyacademy/mcka_apros/pull/1834/files#diff-cc7ad4bcad263f3c78f2d38e62d5be9cR300) is hit and `interaction_data` carries correct values
1.2. Make sure it is only hit *once*
1.3. Make sure it is not hit upon page reload
  