### PR TITLE
[MCKIN-7199] Add feedback for swipe component

### DIFF
--- a/doc/Native APIs.md
+++ b/doc/Native APIs.md
@@ -386,6 +386,8 @@ Swipeable Binary Response (`pb-swipe`)
 - `text`: (string) The text to display on the card
 - `img_url`: (string) URL of the image to display as the background of the card
 - `correct`: (boolean) Whether the student's swipe is correct or not
+- `feedback`: (object) Feedback to display to users in case of correct or 
+  incorrect response.
 
 ### `student_view_user_state`
 
@@ -406,6 +408,8 @@ The returned result will contain the following:
 - `submission`: (boolean) The value just POST'd.
 - `status`: (string) `"correct"` if the swipe is correct, `"incorrect"` otherwise.
 - `score`: (integer) 1 if the swipe is correct, otherwise 0.
+- `feedback`: (string) The ``feedback_correct`` message or ``feedback_incorrect`` 
+  message based on whether the feedback is correct or incorrect. 
 
 Multiple Response Question (`pb-mrq`)
 -------------------------------------

--- a/doc/Questions.md
+++ b/doc/Questions.md
@@ -160,3 +160,19 @@ Screenshot:
 ### "Dashboard" Self-Assessment Summary Block
 
 [Instructions for using the "Dashboard" Self-Assessment Summary Block](Dashboard.md)
+
+### Swipeable Binary Choice Question
+
+The Swipeable Binary Choice Question is a block for creating a UI for selecting 
+an answer by swiping left or right on a touch screen. It is currently in 
+development, and is API-only with no usable interface available to users.
+
+As such it needs to be manually enabled using the following steps:
+
+1. Visit the Django Admin panel for X block configuration at 
+   {STUDIO_URL}/admin/xblock_django/xblockconfiguration/
+2. Click "Add x block configuration"
+3. Enter `pb-swipe` in the `Name` field, check `Enabled` and hit Save. 
+
+You should now see the "Swipeable Binary Choice Question" component as an option
+in Problem Builder.

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -38,3 +38,7 @@ modifying the advanced settings for your course:
 
 Note that it is perfectly fine to enable both Problem Builder and Step Builder
 for your course -- the blocks do not interfere with each other.
+
+NOTE: The ``pb-swipe`` component is currently in development and as such is 
+disabled by default. It needs to be 
+[manually enabled](Questions.md#swipeable-binary-choice-question).

--- a/problem_builder/swipe.py
+++ b/problem_builder/swipe.py
@@ -76,12 +76,24 @@ class SwipeBlock(
         scope=Scope.content,
     )
 
+    feedback_correct = String(
+        display_name=_("Correct Answer Feedback"),
+        help=_("Feedback to display when student answers correctly."),
+        scope=Scope.content,
+    )
+
+    feedback_incorrect = String(
+        display_name=_("Incorrect Answer Feedback"),
+        help=_("Feedback to display when student answers incorrectly."),
+        scope=Scope.content,
+    )
+
     student_choice = Boolean(
         scope=Scope.user_state,
         help=_("Last input submitted by the student.")
     )
 
-    editable_fields = ('display_name', 'text', 'img_url', 'correct')
+    editable_fields = ('display_name', 'text', 'img_url', 'correct', 'feedback_correct', 'feedback_incorrect')
 
     def calculate_results(self, submission):
         correct = submission == self.correct
@@ -89,6 +101,7 @@ class SwipeBlock(
             'submission': submission,
             'status': 'correct' if correct else 'incorrect',
             'score': 1 if correct else 0,
+            'feedback': self.feedback_correct if correct else self.feedback_incorrect,
         }
 
     def get_results(self, previous_result):
@@ -118,6 +131,10 @@ class SwipeBlock(
             'text': self.text,
             'img_url': self.expand_static_url(self.img_url),
             'correct': self.correct,
+            'feedback': {
+                'correct': self.feedback_correct,
+                'incorrect': self.feedback_incorrect,
+            },
         }
 
     def expand_static_url(self, url):

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='2.8.3',
+    version='2.9.0',
     description='XBlock - Problem Builder',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
This PR allows instructors to specify feedback content to be displayed when students provide correct or incorrect answers. 

**Testing instructions**:

1. Manually enable the ``pb-swipe`` block by adding an X block configuration in the studio admin at {STUDIO_URL}/admin/xblock_django/xblockconfiguration/ . The name should be ``pb-swipe`` and it should be set to enabled. 
2. Add a Problem Builder unit and you should see a "Swipeable Binary Choice Question" block.
3. Add the block, edit and fill in the desired values. Note the addition of "Correct answer feedback" and "Incorrect answer feedback". 
4. Publish the unit. 
5. The block and the new feedback fields should now be visible in the Course Blocks API via:
    {LMS_URL}/api/courses/v1/blocks/?course_id=<course_id>&username=staff&depth=all&student_view_data=problem-builder
    It should display the new feedback values in a ``feedback`` object inside ``student_view_data`` for the problem builder block. Note the ``id`` in the ``student_view_data`` block. 
6. You can submit a response to this problem by ``POST``ing to the block's submit handler at
{LMS_URL}/courses/{COURSE_ID}/xblock/{xblock_id}/handler/submit . You will need to post the following: 
```json
{
    "id_from_step_5": { "value": true }
}
```
7. You should see a response that includes the original submission, the status, the score and the feedback text based on whether the submission was correct or not.

**Reviewers**
- [ ] @pomegranited 