### PR TITLE
Add description field to student_view_data for long answer recap block

### DIFF
--- a/doc/Native APIs.md
+++ b/doc/Native APIs.md
@@ -292,6 +292,8 @@ Long Answer Recap (`pb-answer-recap`)
 
 - `block_id`: (string) The XBlock's usage ID (the ID of the associated Long Answer).
 - `display_name`: (string) The XBlock's display name (the title of this Long Answer Recap section).
+- `description`: (string) The XBlock's description (the text message displayed in
+  the Long Answer Recap section).
 - `type`: (string) Always equals `"pb-answer-recap"` for Long Answer Recap components.
 - `id`: (string) Unique ID (name) of the component.
 

--- a/problem_builder/answer.py
+++ b/problem_builder/answer.py
@@ -347,6 +347,7 @@ class AnswerRecapBlock(AnswerMixin, StudioEditableXBlockMixin, XBlock):
             'id': self.name,
             'name': self.name,  # For backwards compatibility; same as 'id'
             'display_name': self.display_name,
+            'description': self.description,
             'block_id': unicode(self.scope_ids.usage_id),
             'type': self.CATEGORY
         }

--- a/problem_builder/tests/unit/test_problem_builder.py
+++ b/problem_builder/tests/unit/test_problem_builder.py
@@ -43,7 +43,7 @@ class TestAnswerRecapBlock(BlockWithChildrenTestMixin, unittest.TestCase):
         self.assertItemsEqual(
             block.student_view_data().keys(),
             [
-                'block_id', 'display_name', 'type', 'id', 'name'
+                'block_id', 'display_name', 'type', 'id', 'name', 'description'
             ]
         )
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='2.9.1',
+    version='2.9.2',
     description='XBlock - Problem Builder',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
This PR adds the ``description`` field to the ``student_view_data`` for the "Long Answer Recap" XBlock so it can be consumed via APIs. 

**Testing instructions**:

1. Install this branch of problem-builder in LMS and Studio
2. Create a "Long Answer" block
3. Create a "Long Answer Recap" block linked to the above
4. Use the course blocks API to fetch the block data for the block using:
``http://localhost:18000/api/courses/v1/blocks/BLOCK_LOCATION/?all_blocks=true&student_view_data=pb-answer-recap``
5. You should see a response like:
```json
{
  "root": "block-v1:opencraft+oc101+2018_1+type@pb-answer-recap+block@3c4f7c1c3a2445dd9d28930f582ccec5",
  "blocks": {
    "block-v1:opencraft+oc101+2018_1+type@pb-answer-recap+block@3c4f7c1c3a2445dd9d28930f582ccec5": {
      "display_name": "Recap d139b8d",
      "block_id": "3c4f7c1c3a2445dd9d28930f582ccec5",
      "student_view_url": "http://localhost:18000/xblock/block-v1:opencraft+oc101+2018_1+type@pb-answer-recap+block@3c4f7c1c3a2445dd9d28930f582ccec5",
      "student_view_data": {
        "display_name": "Recap d139b8d",
        "description": "Description d139b8d",
        "name": "d139b8d",
        "type": "pb-answer-recap",
        "id": "d139b8d",
        "block_id": "block-v1:opencraft+oc101+2018_1+type@pb-answer-recap+block@3c4f7c1c3a2445dd9d28930f582ccec5"
      },
      "lms_web_url": "http://localhost:18000/courses/course-v1:opencraft+oc101+2018_1/jump_to/block-v1:opencraft+oc101+2018_1+type@pb-answer-recap+block@3c4f7c1c3a2445dd9d28930f582ccec5",
      "type": "pb-answer-recap",
      "id": "block-v1:opencraft+oc101+2018_1+type@pb-answer-recap+block@3c4f7c1c3a2445dd9d28930f582ccec5"
    }
  }
}
```

**Reviewers**
- [x] @afzaledx 