### PR TITLE
Fixed feedback close button in RTL

### DIFF
--- a/problem_builder/public/css/questionnaire.css
+++ b/problem_builder/public/css/questionnaire.css
@@ -111,3 +111,9 @@
     border-right: 2px solid #ddd;
     border-left: 0;
 }
+
+.rtl .mentoring .questionnaire .choice-tips .close,
+.rtl .mentoring .questionnaire .feedback .close {
+    right: auto;
+    left: 3px;
+}

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='2.9.2',
+    version='2.9.3',
     description='XBlock - Problem Builder',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
- Fixed feeback close button direction from right to left

**Steps to test the change:**
- Select an option from MCQ/MRQ and click submit
- Feedback close button should be on left in RTL