### PR TITLE
MCKIN-7282: split mcq and mrq question based on ooyala video and return json

### DIFF
--- a/problem_builder/mcq.py
+++ b/problem_builder/mcq.py
@@ -180,6 +180,7 @@ class MCQBlock(SubmittingXBlockMixin, StudentViewUserStateMixin, QuestionnaireAb
             'display_name': self.display_name_with_default,
             'type': self.CATEGORY,
             'question': self.question,
+            'question_parts': self.split_question(),
             'message': self.message,
             'choices': [
                 {'value': choice['value'], 'content': choice['display_name']}

--- a/problem_builder/mrq.py
+++ b/problem_builder/mrq.py
@@ -212,6 +212,7 @@ class MRQBlock(SubmittingXBlockMixin, StudentViewUserStateMixin, QuestionnaireAb
             'type': self.CATEGORY,
             'weight': self.weight,
             'question': self.question,
+            'question_parts': self.split_question(),
             'message': self.message,
             'choices': [
                 {'value': choice['value'], 'content': choice['display_name']}

--- a/problem_builder/questionnaire.py
+++ b/problem_builder/questionnaire.py
@@ -259,7 +259,7 @@ class QuestionnaireAbstractBlock(
             )
             html_before_video = ''.join(
                 [lxml_tostring(node) if type(node) is HtmlElement else node for node in nodes_before_video]
-            )
+            ).strip()
 
             has_noscript_tag = question_html.xpath("boolean(//noscript)")
             if has_noscript_tag:
@@ -269,7 +269,7 @@ class QuestionnaireAbstractBlock(
 
             html_after_video = ''.join(
                 [lxml_tostring(node) if type(node) is HtmlElement else node for node in nodes_after_video]
-            )
+            ).strip()
             ooyala_video_id = next(
                 iter(re.findall("OO.Player.create.*[\"'],\s*[\"'](.*)[\"']", stripped_question) or []), ''
             )

--- a/problem_builder/tests/unit/test_problem_builder.py
+++ b/problem_builder/tests/unit/test_problem_builder.py
@@ -32,6 +32,90 @@ class TestMRQBlock(BlockWithChildrenTestMixin, unittest.TestCase):
         )
 
 
+class TestMCQBlock(BlockWithChildrenTestMixin, unittest.TestCase):
+    def test_student_view_data_question_parts_with_script_and_html(self):
+        """
+        Test that question is being broken into parts correctly.
+        """
+        question_html = """
+        <p>Add the content you want students to see on this page.</p>
+        <script src="//player.ooyala.com/v3/635104fd644c4170ae227af2de27deab"></script>
+        <div id="ooyalaplayer_1" style="width: 320px; height: 180px;"></div>
+        <script>// <![CDATA[
+        OO.ready(function() { OO.Player.create('ooyalaplayer_1', 'VBHbewhjfwjkOEWDNFaskdnwfweNJKWkl'); });
+        // ]]></script>
+        <noscript><div>Please enable Javascript to watch this video</div></noscript><p></p>
+        """
+        expected_question_parts = {
+            'html_before_video': '<p>Add the content you want students to see on this page.</p>',
+            'html_after_video': '<p></p>',
+            'ooyala_video_id': u'VBHbewhjfwjkOEWDNFaskdnwfweNJKWkl'
+        }
+        block = MCQBlock(Mock(), DictFieldData(
+            {
+                'display_name': 'My MCQ',
+                'question': question_html
+            }
+        ), Mock())
+
+        self.assertEqual(
+            block.student_view_data().get('question_parts'),
+            expected_question_parts
+        )
+
+    def test_student_view_data_question_parts_with_script(self):
+        """
+        Test that question is being broken into parts correctly, if question contains script only.
+        """
+        question_html = """
+        <script src="//player.ooyala.com/v3/635104fd644c4170ae227af2de27deab"></script>
+        <div id="ooyalaplayer_1" style="width: 320px; height: 180px;"></div>
+        <script>// <![CDATA[
+        OO.ready(function() { OO.Player.create('ooyalaplayer_1', 'VBHbewhjfwjkOEWDNFaskdnwfweNJKWkl'); });
+        // ]]></script>
+        """
+        expected_question_parts = {
+            'html_before_video': '',
+            'html_after_video': '',
+            'ooyala_video_id': u'VBHbewhjfwjkOEWDNFaskdnwfweNJKWkl'
+        }
+        block = MCQBlock(Mock(), DictFieldData(
+            {
+                'display_name': 'My MCQ',
+                'question': question_html
+            }
+        ), Mock())
+
+        self.assertEqual(
+            block.student_view_data().get('question_parts'),
+            expected_question_parts
+        )
+
+    def test_student_view_data_question_parts_without_script(self):
+        """
+        Test that question is being broken into parts correctly, if question contains no script.
+        """
+        question_html = """
+        <p>Add the content you want students to see on this page.</p>
+        """
+        expected_question_parts = {
+            'html_before_video': '<p>Add the content you want students to see on this page.</p>',
+            'html_after_video': '',
+            'ooyala_video_id': ''
+        }
+        block = MCQBlock(Mock(), DictFieldData(
+            {
+                'display_name': 'My MCQ',
+                'question': question_html
+            }
+        ), Mock())
+
+        self.assertEqual(
+            block.student_view_data().get('question_parts'),
+            expected_question_parts
+        )
+
+
 @ddt.ddt
 class TestAnswerRecapBlock(BlockWithChildrenTestMixin, unittest.TestCase):
     def test_student_view_data(self):

--- a/problem_builder/tests/unit/test_problem_builder.py
+++ b/problem_builder/tests/unit/test_problem_builder.py
@@ -26,8 +26,8 @@ class TestMRQBlock(BlockWithChildrenTestMixin, unittest.TestCase):
         self.assertItemsEqual(
             block.student_view_data().keys(),
             [
-                'hide_results', 'tips', 'block_id', 'display_name',
-                'weight', 'title', 'question', 'message', 'type', 'id', 'choices'
+                'hide_results', 'tips', 'block_id', 'display_name', 'weight',
+                'question_parts', 'title', 'question', 'message', 'type', 'id', 'choices'
             ]
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ddt
 mock
+lxml==4.2.1
 unicodecsv==0.9.4
 edx-opaque-keys>=0.4
 -e git+https://github.com/edx/xblock-utils.git@v1.0.3#egg=xblock-utils


### PR DESCRIPTION
This PR adds new attribute `question_parts` to `student_view_data` for MCQ and MRQ. If MCQ/MRQ question contains ooyala video we split question into parts and extract ooyala video id from the script and return it in json format.
