### PR TITLE
Fix: default 'correctness' of swipe is null, not false (MCKIN-7547)

### DIFF
--- a/problem_builder/swipe.py
+++ b/problem_builder/swipe.py
@@ -74,6 +74,7 @@ class SwipeBlock(
         display_name=_("Correct Choice"),
         help=_("Specifies whether the card is correct."),
         scope=Scope.content,
+        default=False,
     )
 
     feedback_correct = String(

--- a/problem_builder/tests/unit/test_swipe.py
+++ b/problem_builder/tests/unit/test_swipe.py
@@ -1,0 +1,19 @@
+import ddt
+import unittest
+from mock import Mock
+
+from xblock.field_data import DictFieldData
+from problem_builder.swipe import SwipeBlock
+
+
+@ddt.ddt
+class TestSwipeBlock(unittest.TestCase):
+    def test_student_view_data(self):
+        """
+        Ensure that all expected fields are always returned with
+        appropriate values.
+        """
+        runtime = Mock(replace_urls=lambda url: '"{}"'.format(url))
+        block = SwipeBlock(runtime, DictFieldData({"display_name": "Test"}), Mock())
+
+        self.assertEqual(block.student_view_data()['correct'], False)

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='3.0.0',
+    version='3.0.1',
     description='XBlock - Problem Builder',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
When adding a "Swipe" component to problem builder in Studio, if the author leaves the default value of:
<img width="774" alt="screen shot 2018-05-28 at 11 22 04 am" src="https://user-images.githubusercontent.com/945577/40621095-62f33884-6269-11e8-8b7b-a69d7583772d.png">
then the student_view_data API will include:

    "correct": null

instead of the expected value of

    "correct": false

This PR fixes it. Note that NULL values should never have actually been saved into mongodb, so there's no concern over backwards compatibility. This only affects blocks where the field value wasn't saved at all.

**Testing instructions**

1. Make sure [the swipe component is enabled](https://github.com/open-craft/problem-builder/blob/master/doc/Questions.md#swipeable-binary-choice-question).
2. Create/find a course containing a problem builder with a swipe component. Leave the default "correctness" value unchanged.
3. Check [the student_view_data API](https://github.com/open-craft/problem-builder/blob/master/doc/Native%20APIs.md) result and observe it contains `"correct": null` :/
4. Check out this branch and restart the LMS and Studio
5. Publish a change to the course, to force the student_view_data cache to rebuild
6. Check the student_view_data API again and observe it now contains `"correct": false` :)