### PR TITLE
Version 3.1.3, automatic PyPI uploads

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,9 +14,6 @@ jobs:
             virtualenv venv
             . venv/bin/activate
             pip install -U pip wheel
-            # Temporarily pin setuptools to a specific version.
-            # See commit message of https://github.com/open-craft/problem-builder/commit/51277a34fb426724616618c1afdb893ab2de4c6b for more info:
-            pip install setuptools==24.3.1
             pip install -e git://github.com/edx/xblock-sdk.git@bddf9f4a2c6e4df28a411c8f632cc2250170ae9d#egg=xblock-sdk
             pip install -r requirements.txt
             pip install -r venv/src/xblock-sdk/requirements/base.txt
@@ -45,3 +42,59 @@ jobs:
             if [ $CIRCLE_NODE_INDEX = '1' ]; then pylint problem_builder --disable=all --enable=function-redefined,undefined-variable,unused-import,unused-variable; fi
             TESTFILES=$(circleci tests glob "problem_builder/v1/tests/**/*.py" "problem_builder/tests/**/*.py"| circleci tests split)
             xvfb-run --server-args="-screen 0 1280x1024x24" python run_tests.py ${TESTFILES}
+
+  deploy:
+    docker:
+      - image: circleci/python:2.7.14
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependencies-{{ checksum "circle.yml" }}-{{ checksum "setup.py" }}
+      - run:
+          name: Install dependencies
+          command: |
+            virtualenv venv
+            . venv/bin/activate
+            pip install -U pip twine wheel
+      - save_cache:
+          key: dependencies-{{ checksum "circle.yml" }}-{{ checksum "setup.py" }}
+          paths:
+            - "venv"
+      - run:
+          name: Verify commit is tagged and tag matches version
+          command: |
+            . venv/bin/activate
+            python setup.py verify_tag
+      - run:
+          name: Initialize .pypirc
+          command: |
+            echo -e "[pypi]" >> ~/.pypirc
+            echo -e "username = opencraft" >> ~/.pypirc
+            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
+      - run:
+          name: Create packages
+          command: |
+            python setup.py sdist
+            python setup.py bdist_wheel
+      - run:
+          name: Upload to pypi
+          command: |
+            . venv/bin/activate
+            twine upload dist/*
+
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - deploy:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,14 @@
 # Imports ###########################################################
 
 import os
+import sys
 from setuptools import setup, find_packages
+from setuptools.command.install import install
+
+
+# Constants #########################################################
+
+VERSION = '3.1.3'
 
 
 # Functions #########################################################
@@ -35,6 +42,20 @@ def package_data(pkg, root_list):
                 data.append(os.path.relpath(os.path.join(dirname, fname), pkg))
 
     return {pkg: data}
+
+
+class VerifyTagCommand(install):
+    """Custom command to verify that the git tag matches the current version."""
+    description = 'verify that the git tag matches the current version'
+
+    def run(self):
+        tag = os.getenv('CIRCLE_TAG')
+
+        if tag != 'v{}'.format(VERSION):
+            info = "Git tag: {0} does not match the version of this app: {1}".format(
+                tag, VERSION
+            )
+            sys.exit(info)
 
 
 # Main ##############################################################
@@ -72,7 +93,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='3.1.2',
+    version=VERSION,
     description='XBlock - Problem Builder',
     packages=find_packages(),
     install_requires=[
@@ -83,4 +104,7 @@ setup(
         'xblock.v1': BLOCKS,
     },
     package_data=package_data("problem_builder", ["templates", "public", "migrations"]),
+    cmdclass={
+        'verify_tag': VerifyTagCommand,
+    },
 )


### PR DESCRIPTION
This bumps the version and attempts to set up automated PyPI uploads via CircleCI following the advice in [their blog post on the topic](https://circleci.com/blog/continuously-deploying-python-packages-to-pypi-with-circleci/):

* Removed an obsolete pin on an old version of setuptools (the referenced bug was long since fixed)
* Added a deployment job.
* Only run the deployment job for git tag pushes, and only if the build job for the same push succeeds.

Before the automatic uploads will work, you need to add the `PYPI_PASSWORD` environment variable to the CircleCI settings, as explained [here](https://circleci.com/docs/2.0/env-vars/#overview) ("the Environment Variables page of the Build > Project > Settings in the CircleCI application").  This should be the PyPI password of the opencraft account.

It used to be necessary to manually register a package on PyPI before uploading the first release, but it looks like with the switch to Warehouse this is no longer needed.