### PR TITLE
Fix failing CI checks

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,6 +32,7 @@ jobs:
           name: Install firefox 38.0.5
           command: |
             FIREFOX_URL="https://sourceforge.net/projects/ubuntuzilla/files/mozilla/apt/pool/main/f/firefox-mozilla-build/firefox-mozilla-build_38.0.5-0ubuntu1_amd64.deb/download" \
+            && sudo apt-get update \
             && curl --silent --show-error --location --fail --retry 3 --output /tmp/firefox.deb $FIREFOX_URL \
             && sudo dpkg -i /tmp/firefox.deb || sudo apt-get -f install  \
             && sudo apt-get install -y libgtk3.0-cil-dev libasound2 libasound2 libdbus-glib-1-2 libdbus-1-3 libgtk2.0-0 \

--- a/problem_builder/mixins.py
+++ b/problem_builder/mixins.py
@@ -288,7 +288,6 @@ class StudentViewUserStateResultsTransformerMixin(ExpandStaticURLMixin):
 
         return student_results
 
-
     def delete_key(self, dictionary, key):
         """
         Safely delete `key` from `dictionary`.

--- a/problem_builder/tests/integration/test_instructor_tool.py
+++ b/problem_builder/tests/integration/test_instructor_tool.py
@@ -162,6 +162,8 @@ class InstructorToolTest(SeleniumXBlockTest):
         self.wait_until_visible(download_button)
         self.wait_until_hidden(cancel_button)
         self.wait_until_visible(delete_button)
+        time.sleep(1)
+
         for column in [
                 'Section', 'Subsection', 'Unit',
                 'Type', 'Question', 'Answer', 'Username'


### PR DESCRIPTION
This PR fixes the issues causing the CI checks to fail.

* Run apt-get update before installing packages (cherry-picked from the master branch).
* Fix code style issues.
* Add a delay in the failing test for the result block content to show up.