### PR TITLE
Add a delay in the test for the result block content to show up

### DIFF
--- a/problem_builder/tests/integration/test_instructor_tool.py
+++ b/problem_builder/tests/integration/test_instructor_tool.py
@@ -162,6 +162,8 @@ class InstructorToolTest(SeleniumXBlockTest):
         self.wait_until_visible(download_button)
         self.wait_until_hidden(cancel_button)
         self.wait_until_visible(delete_button)
+        time.sleep(1)
+
         for column in [
                 'Section', 'Subsection', 'Unit',
                 'Type', 'Question', 'Answer', 'Username'


### PR DESCRIPTION
This fixes an integration test failure. The change is based on the fix in https://github.com/open-craft/problem-builder/pull/211