### PR TITLE
[BB-643] Fix the StopIteration exception error

### DIFF
--- a/problem_builder/tasks.py
+++ b/problem_builder/tasks.py
@@ -213,7 +213,7 @@ def get_users_by_anonymous_ids(anonymous_ids):
     ).iterator()
 
     return {
-        user['anonymous_user_id']: user['username'], user['id'], user['email']) for user in users
+        user['anonymous_user_id']: (user['username'], user['id'], user['email']) for user in users
     }
 
 

--- a/problem_builder/tasks.py
+++ b/problem_builder/tasks.py
@@ -217,7 +217,6 @@ def get_users_by_anonymous_ids(anonymous_ids):
     }
 
 
-
 def _get_answer(block, submission, answer_cache):
     """
     Return answer associated with `submission` to `block`.

--- a/problem_builder/tasks.py
+++ b/problem_builder/tasks.py
@@ -203,7 +203,10 @@ def _get_user_info(users, submission):
     """
     user = None
     if users is not None:
-        user = next(user for user in users if user.anonymous_user_id == submission['student_id'])
+        try:
+            user = next(user for user in users if user.anonymous_user_id == submission['student_id'])
+        except StopIteration:
+            pass
 
     if user is None:
         return (submission['student_id'], 'N/A', 'N/A')

--- a/problem_builder/tasks.py
+++ b/problem_builder/tasks.py
@@ -213,7 +213,7 @@ def get_users_by_anonymous_ids(anonymous_ids):
     ).iterator()
 
     return {
-        user['anonymous_user_id']: (user['id'], user['username'], user['email']) for user in users
+        user['anonymous_user_id']: user['username'], user['id'], user['email']) for user in users
     }
 
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ BLOCKS = [
 
 setup(
     name='xblock-problem-builder',
-    version='2.11.3',
+    version='2.11.4',
     description='XBlock - Problem Builder',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
When the submission of a user is not found, calling `next()` on the generator expression throws a `StopIteration` exception which was not handled. This PR adds a `try-except` handler for the exception. The `except` block does nothing because this situation is handled in the following `if` condition.

**Testing instructions**
1. Clone and Install problem_builder with the PR branch.
1. From studio Add problem builder block containing MCQ/MRQ and Instructor tool block.
1. Go to Apros and attempt question in problem builder block.
1. Do the previous step for a few users.
1. Delete one of the users used in the previous step.
1. Go to Instructor tool block in apros and click search and it will start exporting for all blocks.
1. Verify that there was no exception thrown and `(<student ID>, 'N/A', 'N/A')` is returned for that user corresponding to that submission.
1. Alternatively, modify [this line](https://github.com/open-craft/problem-builder/pull/218/files#diff-62503b7f5c87c7f593fba9e2a54320fbR215) to return `{}` and verify that `(<student ID>, 'N/A', 'N/A')` is returned for that user corresponding to that submission.
