### PR TITLE
[MCKIN-9274] Fix step-builder bug ("Message Review(s)" button not showing)

### DIFF
--- a/problem_builder/questionnaire.py
+++ b/problem_builder/questionnaire.py
@@ -164,8 +164,12 @@ class QuestionnaireAbstractBlock(
         fragment = self.get_author_edit_view_fragment(context)
 
         # * Step Builder units can show review components in the Review Step.
+        show_review = isinstance(
+            self.get_parent().get_parent() if self.get_parent() else None,
+            MentoringWithExplicitStepsBlock
+        )
         fragment.add_content(loader.render_template('templates/html/questionnaire_add_buttons.html', {
-            'show_review': isinstance(self.get_parent(), MentoringWithExplicitStepsBlock)
+            'show_review': show_review
         }))
         fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/problem-builder.css'))
         fragment.add_css_url(self.runtime.local_resource_url(self, 'public/css/questionnaire-edit.css'))

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools.command.install import install
 
 # Constants #########################################################
 
-VERSION = '3.2.0'
+VERSION = '3.2.1'
 
 # Functions #########################################################
 


### PR DESCRIPTION
This PR fixes a small bug where the button "Message Review(s)" didn't show up when using MCQ/MRQ in step builder mode.

**JIRA tickets**: [BB-807](https://tasks.opencraft.com/browse/BB-807) and MCKIN-9274

**Testing instructions:**
1. Install master branch on your devstack.
2. Go to Studio, in the edX Demonstration Course, and click on Settings -> Advanced Settings, then add 
`"problem-builder","step-builder" ` to `Advanced Module List` Field and click Save Changes.
2.  Create a new Section, Subsection and Unit.
3. Add the step builder component, add a mentoring step, enter in the mentoring step and add a `Multiple Response Question` and a `Multiple Choice Question`.
4. Enter on each question and check that the only options are "Add Custom Choice" and "Add Tip"
![issue](https://user-images.githubusercontent.com/27893385/51328070-b86be100-1a59-11e9-87ce-0bf09f85e01b.png)
5. Checkout this branch and restart Studio.
6. Check that the button "Message Review(s)" appears in both problems.
![fixed](https://user-images.githubusercontent.com/27893385/51328178-f0732400-1a59-11e9-97b9-b0cab47ebdd9.png)

**Reviewers:**
- [x] @xitij2000 