### PR TITLE
BB-785 deleting Answer data via Django signals

### DIFF
--- a/problem_builder/models.py
+++ b/problem_builder/models.py
@@ -27,9 +27,8 @@ from django.contrib.auth.models import User
 try:
     # workaround so we don't explicitly import the AnonymousUserId model from LMS
     from student.models import AnonymousUserId
-    ANONYMOUS_USER_ID_IMPORTED = True
 except ImportError:
-    ANONYMOUS_USER_ID_IMPORTED = False
+    AnonymousUserId = None
 
 
 # Classes ###########################################################
@@ -92,5 +91,5 @@ def delete_anonymous_user_answers(sender, **kwargs):
     Answer.objects.filter(student_id=instance.anonymous_user_id).delete()
 
 
-if ANONYMOUS_USER_ID_IMPORTED:
+if AnonymousUserId:
     pre_delete.connect(delete_anonymous_user_answers, sender=AnonymousUserId)

--- a/problem_builder/tests/unit/test_models.py
+++ b/problem_builder/tests/unit/test_models.py
@@ -42,31 +42,3 @@ class AnswerDeleteSignalTest(TestCase):
         delete_anonymous_user_answers(MagicMock(), instance=anonymous_user_id_mock)
         self.assertEqual(Answer.objects.filter(student_id=self.anonymous_student_id).count(), 0)
         self.assertEqual(Answer.objects.exclude(student_id=self.anonymous_student_id).count(), 1)
-
-    def test_signal_receiver_connection(self):
-        """
-        Test the receiver function by deleting the parent User object.
-        TODO: figure out how to run this test
-        """
-        try:
-            from student.models import AnonymousUserId
-        except ImportError:
-            raise unittest.SkipTest('student.AnonymousUserId not available')
-
-        user = User.objects.create(username='edx', email='edx@example.com')
-        AnonymousUserId.objects.create(user=user, anonymous_user_id=self.anonymous_student_id)
-
-        # a different anonymous id for the same user
-        AnonymousUserId.objects.create(user=user, anonymous_user_id='12345678987654321-x')
-        Answer.objects.create(
-            name='test-course-key-3',
-            student_id='12345678987654321-x',
-            course_key=self.course_id,
-        )
-
-        self.assertEqual(Answer.objects.count(), 4)
-
-        user.delete()
-
-        # edx's answers should be deleted, leaving the one from the other user
-        self.assertEqual(Answer.objects.count(), 1)

--- a/problem_builder/tests/unit/test_models.py
+++ b/problem_builder/tests/unit/test_models.py
@@ -1,10 +1,8 @@
 """
 Unit tests for models.
 """
-import unittest
 from mock import MagicMock, PropertyMock
 
-from django.contrib.auth.models import User
 from django.test import TestCase
 
 from problem_builder.models import Answer, delete_anonymous_user_answers

--- a/problem_builder/tests/unit/test_models.py
+++ b/problem_builder/tests/unit/test_models.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for models.
+"""
+import unittest
+from mock import MagicMock, PropertyMock
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from problem_builder.models import Answer, delete_anonymous_user_answers
+
+
+class AnswerDeleteSignalTest(TestCase):
+    """ Unit tests for pre_delete signal receiver. """
+
+    def setUp(self):
+        super(AnswerDeleteSignalTest, self).setUp()
+        self.course_id = 'course-v1:edX+DemoX+Demo_Course'
+        self.anonymous_student_id = '123456789876543210'
+        Answer.objects.create(
+            name='test-course-key',
+            student_id=self.anonymous_student_id,
+            course_key=self.course_id,
+        )
+        Answer.objects.create(
+            name='test-course-key-2',
+            student_id=self.anonymous_student_id,
+            course_key=self.course_id,
+        )
+        Answer.objects.create(
+            name='test-course-key',
+            student_id='other-user',
+            course_key=self.course_id,
+        )
+
+    def test_delete_anonymous_user_answers(self):
+        """
+        Test the receiver function by calling it directly.
+        """
+        anonymous_user_id_mock = MagicMock()
+        type(anonymous_user_id_mock).anonymous_user_id = PropertyMock(return_value=self.anonymous_student_id)
+        delete_anonymous_user_answers(MagicMock(), instance=anonymous_user_id_mock)
+        self.assertEqual(Answer.objects.filter(student_id=self.anonymous_student_id).count(), 0)
+        self.assertEqual(Answer.objects.exclude(student_id=self.anonymous_student_id).count(), 1)
+
+    def test_signal_receiver_connection(self):
+        """
+        Test the receiver function by deleting the parent User object.
+        TODO: figure out how to run this test
+        """
+        try:
+            from student.models import AnonymousUserId
+        except ImportError:
+            raise unittest.SkipTest('student.AnonymousUserId not available')
+
+        user = User.objects.create(username='edx', email='edx@example.com')
+        AnonymousUserId.objects.create(user=user, anonymous_user_id=self.anonymous_student_id)
+
+        # a different anonymous id for the same user
+        AnonymousUserId.objects.create(user=user, anonymous_user_id='12345678987654321-x')
+        Answer.objects.create(
+            name='test-course-key-3',
+            student_id='12345678987654321-x',
+            course_key=self.course_id,
+        )
+
+        self.assertEqual(Answer.objects.count(), 4)
+
+        user.delete()
+
+        # edx's answers should be deleted, leaving the one from the other user
+        self.assertEqual(Answer.objects.count(), 1)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ transifex-client==0.12.1
 edx-i18n-tools==0.4.5
 pycodestyle==2.4.0
 pylint==0.28.0
+django-pyfs==2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,3 @@ transifex-client==0.12.1
 edx-i18n-tools==0.4.5
 pycodestyle==2.4.0
 pylint==0.28.0
-django-pyfs==2.0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools.command.install import install
 
 # Constants #########################################################
 
-VERSION = '3.2.1'
+VERSION = '3.3.0'
 
 # Functions #########################################################
 


### PR DESCRIPTION
This PR adds a Django signal handler to delete `Answer` objects when a `django.contrib.auth.User` object is deleted from LMS.

The `Answer` model has a field for `student_id` which stores a string [taken](https://github.com/open-craft/problem-builder/blob/john2x/BB-785-delete-xblock-custom-model/problem_builder/answer.py#L67) from `student.AnonymousUserId.anonymous_user_id`.

The signal receiver function connects to `AnonymousUserId` instead of `User` because the former will get deleted via CASCADE when the latter is deleted.

# Test instructions

## Minimal Setup

Create a test course with at least a "Long Answer Question" component from this package

## Expanded Setup

The expanded setup is similar to the minimal setup, but would include modules/components from the XBlocks listed in [the Jira ticket](https://tasks.opencraft.com/browse/BB-785?focusedCommentId=101483&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-101483).

## Verify behavior

1. Check out this branch and install this package into your devstack
2. Start the course as a user
3. Submit answers to the modules/components
4. As you are going through the course, make sure to add some bookmarks
   - Author's note: To add bookmarks, I had to do it via the LMS UI and not Apros
5. After completing the course, verify the records stored for the user:
    ```
    >>> user = User.objects.get(username='john')
    >>> Bookmark.objects.filter(user=user).count()
    1
    >>> StudentModule.objects.filter(student=user).count()
    27
    >>> XModuleStudentInfoField.objects.filter(student=user).count()
    0
    >>> XModuleStudentPrefsField.objects.filter(student=user).count()
    0
    >>> AnonymousUserId.objects.filter(user=user).count()
    2
    >>> Answer.objects.filter(student_id__in=AnonymousUserId.objects.filter(user=user).values_list('anonymous_user_id', flat=True)).count()
    1
    ```
6. Delete the user
    ```
    >>> user.delete()
    ```
7. Verify the records for the user have been deleted
    ```
    >>> Bookmark.objects.filter(user=user).count()
    0
    >>> StudentModule.objects.filter(student=user).count()
    0
    >>> XModuleStudentPrefsField.objects.filter(student=user).count()
    0
    >>> AnonymousUserId.objects.filter(user=user).count()
    0
    >>> Answer.objects.filter(student_id__in=AnonymousUserId.objects.filter(user=user).values_list('anonymous_user_id', flat=True)).count()
    0
    >>> Answer.objects.all.count()
    0
    ```

# Author's notes and concerns

- Added `django-pyfs` as a dependency in `requirements-dev.txt` because `run_tests.py` was failing to run without it
- The [`test_signal_receiver_connection` test](https://github.com/open-craft/problem-builder/compare/john2x/BB-785-delete-xblock-custom-model?expand=1#diff-87000eee015fac540c3d5af65ad462c5R47) is currently skipped. Need to figure out how to run it.