### PR TITLE
MCKIN-8902: Fix issue on the score summary page.

### DIFF
--- a/problem_builder/public/js/mentoring_with_steps.js
+++ b/problem_builder/public/js/mentoring_with_steps.js
@@ -283,6 +283,7 @@ function MentoringWithStepsBlock(runtime, element) {
     function jumpToReview(stepIndex) {
         activeStepIndex = stepIndex;
         cleanAll();
+        clearSelections();
         showActiveStep();
         updateNextLabel();
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools.command.install import install
 
 # Constants #########################################################
 
-VERSION = '3.3.3'
+VERSION = '3.3.4'
 
 # Functions #########################################################
 


### PR DESCRIPTION
### [https://edx-wiki.atlassian.net/browse/MCKIN-8902](https://edx-wiki.atlassian.net/browse/MCKIN-8902)
After the final attempt of assessment when the user navigates from the score summary to the feedback tips then there is discrimination between the user selected options (checkboxes) because the previously selected options are also shown in the next steps.
 
Please see the attached screenshots for better understanding.
**1st:**
![Screenshot (1)](https://user-images.githubusercontent.com/7627421/56714218-95825480-674d-11e9-90a3-eaccacb8225a.png)
**2nd**
![Screenshot (2)](https://user-images.githubusercontent.com/7627421/56714290-d1b5b500-674d-11e9-8a76-347a052f6779.png)
**3rd**
![Screenshot (3)](https://user-images.githubusercontent.com/7627421/56714300-d9755980-674d-11e9-99fc-de5e1597d82f.png)
**4th**
![Screenshot (4)](https://user-images.githubusercontent.com/7627421/56714329-f14cdd80-674d-11e9-8ab5-932798b86f63.png)
**5th**
![Screenshot (5)](https://user-images.githubusercontent.com/7627421/56714415-2c4f1100-674e-11e9-9b4e-6aceec1aee4a.png)


CC: @msaqib52 

