### PR TITLE
BB-1330: Fix overlapping feedback fields

### DIFF
--- a/problem_builder/public/css/questionnaire.css
+++ b/problem_builder/public/css/questionnaire.css
@@ -65,7 +65,7 @@
     overflow-y: auto;
     line-height: normal;
     max-height: 100px;
-    margin: 5px 0 5px 0;
+    margin: 5px 0;
 }
 
 .mentoring .questionnaire .choice-tips p,

--- a/problem_builder/public/css/questionnaire.css
+++ b/problem_builder/public/css/questionnaire.css
@@ -64,7 +64,8 @@
     position: relative;
     overflow-y: auto;
     line-height: normal;
-    max-height: 180px;
+    max-height: 100px;
+    margin: 5px 0 5px 0;
 }
 
 .mentoring .questionnaire .choice-tips p,


### PR DESCRIPTION
This fixes a text overlap when using the feedback message functionality of the XBlock.

**Testing instructions:**
1. Install the `master` branch of this repo on your devstack using `pip install -e /edx/src/problem-builder` (assuming problem builder is there.
2. Create a new course, add `problem-builder` to the advanced modules and add it to a unit.
3. Add 3 multiple choice questions and fill the **Message** fields with a long text.
4. Go into the LMS and answer the questions, you should see something like this:
![2019-06-13_15-23](https://user-images.githubusercontent.com/27893385/59458398-be8ba100-8df0-11e9-98e7-2307933faab1.png)
5. Check out this branch and test again. The issues should be fixed.
![fixed](https://user-images.githubusercontent.com/27893385/59458457-dbc06f80-8df0-11e9-8142-c14632809879.png)

**Reviewers:**
- [ ] @lgp171188 

**Authors notes:**
- Tested this on Chrome, Firefox and using multiple resolutions from 800x600 to 1920x1080. 
- Looks broken on mobile, but already looked broken before the fix and it's not in the scope of the fix.