### PR TITLE
MCKIN-12122: add FOR attribute in mcq and mrq input labels

### DIFF
--- a/problem_builder/templates/html/mcqblock.html
+++ b/problem_builder/templates/html/mcqblock.html
@@ -8,6 +8,7 @@
     {% for choice in custom_choices %}
     <div class="choice" aria-live="polite" aria-atomic="true">
       <label class="choice-label"
+             for="{{ self.html_id }}_{{ forloop.counter }}"
              aria-describedby="feedback_{{ self.html_id }} choice_tips_{{ self.html_id }}-{{ forloop.counter }}">
         <span class="choice-result fa icon-2x"
               aria-label=""
@@ -15,6 +16,7 @@
               data-label_incorrect="{% trans "Incorrect" %}"></span>
         <span class="choice-selector">
           <input type="radio" name="{{ self.name }}" value="{{ choice.value }}"
+            id="{{ self.html_id }}_{{ forloop.counter }}"
             {% if self.student_choice == choice.value and not hide_prev_answer %} checked{% endif %}
           />
         </span>

--- a/problem_builder/templates/html/mrqblock.html
+++ b/problem_builder/templates/html/mrqblock.html
@@ -13,11 +13,14 @@
            aria-label=""
            data-label_correct="{% trans "Correct" %}"
            data-label_incorrect="{% trans "Incorrect" %}"></div>
-      <label class="choice-label" aria-describedby="feedback_{{ self.html_id }}
+      <label class="choice-label"
+             for="{{ self.html_id }}_{{ forloop.counter }}"
+             aria-describedby="feedback_{{ self.html_id }}
                                                     result_{{ self.html_id }}-{{ forloop.counter }}
                                                     choice_tips_{{ self.html_id }}-{{ forloop.counter }}">
         <span class="choice-selector">
           <input type="checkbox" name="{{ self.name }}" value="{{ choice.value }}"
+             id="{{ self.html_id }}_{{ forloop.counter }}"
              {% if choice.value in self.student_choices and not hide_prev_answer %} checked{% endif %}
           />
         </span>

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools.command.install import install
 
 # Constants #########################################################
 
-VERSION = '3.3.11'
+VERSION = '3.3.12'
 
 # Functions #########################################################
 


### PR DESCRIPTION
The radio buttons and checkboxes for the mcq and mrq are not programmatically associated with its on-screen label and may not be rendered via all assistive technologies correctly. This PR links labels with their respective input fields using for attribute.

@xitij2000 could you review this PR?