### PR TITLE
MCKIN-12203 AF#91-MRQ-Ensure custom controls are keyboard accessible

### DIFF
--- a/problem_builder/public/css/questionnaire.css
+++ b/problem_builder/public/css/questionnaire.css
@@ -22,6 +22,10 @@
 
 .mentoring div[data-block-type=pb-mrq] .questionnaire .choice-result {
     display: inline-block;
+    padding: 0;
+    margin: 0;
+    background: none;
+    border: none;
 }
 
 .mentoring .questionnaire .choice {

--- a/problem_builder/public/css/questionnaire.css
+++ b/problem_builder/public/css/questionnaire.css
@@ -23,7 +23,7 @@
 .mentoring div[data-block-type=pb-mrq] .questionnaire .choice-result {
     display: inline-block;
     padding: 0;
-    margin: 0;
+    margin: 0 5px;
     background: none;
     border: none;
     outline: none;

--- a/problem_builder/public/css/questionnaire.css
+++ b/problem_builder/public/css/questionnaire.css
@@ -26,6 +26,7 @@
     margin: 0;
     background: none;
     border: none;
+    outline: none;
 }
 
 .mentoring .questionnaire .choice {

--- a/problem_builder/templates/html/mrqblock.html
+++ b/problem_builder/templates/html/mrqblock.html
@@ -8,11 +8,11 @@
   <div class="choices-list">
     {% for choice in custom_choices %}
     <div class="choice" aria-live="polite" aria-atomic="true">
-      <div class="choice-result fa icon-2x"
+      <button class="choice-result fa icon-2x"
            id="result_{{ self.html_id }}-{{ forloop.counter }}"
            aria-label=""
            data-label_correct="{% trans "Correct" %}"
-           data-label_incorrect="{% trans "Incorrect" %}"></div>
+           data-label_incorrect="{% trans "Incorrect" %}"></button>
       <label class="choice-label"
              for="{{ self.html_id }}_{{ forloop.counter }}"
              aria-describedby="feedback_{{ self.html_id }}

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools.command.install import install
 
 # Constants #########################################################
 
-VERSION = '3.3.13'
+VERSION = '3.3.14'
 
 # Functions #########################################################
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools.command.install import install
 
 # Constants #########################################################
 
-VERSION = '3.3.12'
+VERSION = '3.3.13'
 
 # Functions #########################################################
 


### PR DESCRIPTION
MCKIN-12203 AF#91-MRQ-Ensure custom controls are keyboard accessible

Description

[Issue]
The feedback icons aren't keyboard accessible since div elements do not natively receive keyboard focus.

[User Impact]
When custom elements do not provide keyboard access, keyboard only users and users of assistive technology may not be able to use or interact with the custom control. 

[Code Reference]
<div class="choice-result fa icon-2x checkmark-incorrect icon-exclamation fa-exclamation" id="result_e3e109293d1944ce80c1-1" aria-label="Incorrect" data-label_correct="Correct" data-label_incorrect="Incorrect"></div>


Environment

[Recommended Solution]
Use the <button> element to ensure keyboard focus by default.