### PR TITLE
BOM-1146

### DIFF
--- a/problem_builder/migrations/0001_initial.py
+++ b/problem_builder/migrations/0001_initial.py
@@ -17,9 +17,9 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=50, db_index=True)),
                 ('student_id', models.CharField(max_length=32, db_index=True)),
                 ('course_id', models.CharField(max_length=50, db_index=True)),
-                ('student_input', models.TextField(default=b'', blank=True)),
-                ('created_on', models.DateTimeField(auto_now_add=True, verbose_name=b'created on')),
-                ('modified_on', models.DateTimeField(auto_now=True, verbose_name=b'modified on')),
+                ('student_input', models.TextField(default=u'', blank=True)),
+                ('created_on', models.DateTimeField(auto_now_add=True, verbose_name=u'created on')),
+                ('modified_on', models.DateTimeField(auto_now=True, verbose_name=u'modified on')),
             ],
         ),
         migrations.AlterUniqueTogether(

--- a/problem_builder/models.py
+++ b/problem_builder/models.py
@@ -52,9 +52,9 @@ class Answer(models.Model):
     name = models.CharField(max_length=50, db_index=True)
     student_id = models.CharField(max_length=50, db_index=True)
     course_key = models.CharField(max_length=255, db_index=True)
-    student_input = models.TextField(blank=True, default='')
-    created_on = models.DateTimeField('created on', auto_now_add=True)
-    modified_on = models.DateTimeField('modified on', auto_now=True)
+    student_input = models.TextField(blank=True, default=u'')
+    created_on = models.DateTimeField(u'created on', auto_now_add=True)
+    modified_on = models.DateTimeField(u'modified on', auto_now=True)
 
     def save(self, *args, **kwargs):
         # Force validation of max_length

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools.command.install import install
 
 # Constants #########################################################
 
-VERSION = '3.4.4'
+VERSION = '3.4.5'
 
 # Functions #########################################################
 


### PR DESCRIPTION
For last one month in edx-platform `test_migrations_are_in_sync` test was disabled due to some schema changes. Yesterday this test enabled and failing due to some new migrations changes under python3. It was due to the prefix `b` in few fields. 