### PR TITLE
MCKIN-12690 Fix Score rounding

### DIFF
--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -433,7 +433,7 @@ class MentoringBlock(
 
         return Score(
             float(score),
-            int((Decimal(score) * 100).quantize(Decimal('1.'), rounding=ROUND_HALF_UP)),
+            int(Decimal(score * 100).quantize(Decimal('1.'), rounding=ROUND_HALF_UP)),
             correct,
             incorrect,
             partially_correct

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools.command.install import install
 
 # Constants #########################################################
 
-VERSION = '3.4.12'
+VERSION = '3.4.13'
 
 # Functions #########################################################
 


### PR DESCRIPTION
Jira ticket: https://edx-wiki.atlassian.net/browse/MCKIN-12690
Python 3:
Decimal(0.485) = 0.4849999
Decimal(48.5) = 48.5

Due to above mentioned, rounding is in-accurate.
We need to multiply score by 100 before giving it as input to Decimal(xxx).