### PR TITLE
Fixing django2 compatible items.

### DIFF
--- a/problem_builder/migrations/0002_auto_20160121_1525.py
+++ b/problem_builder/migrations/0002_auto_20160121_1525.py
@@ -20,8 +20,8 @@ class Migration(migrations.Migration):
                 ('submission_uid', models.CharField(max_length=32)),
                 ('block_id', models.CharField(max_length=255, db_index=True)),
                 ('notified', models.BooleanField(default=False, db_index=True)),
-                ('shared_by', models.ForeignKey(related_name='problem_builder_shared_by', to=settings.AUTH_USER_MODEL)),
-                ('shared_with', models.ForeignKey(related_name='problem_builder_shared_with', to=settings.AUTH_USER_MODEL)),
+                ('shared_by', models.ForeignKey(related_name='problem_builder_shared_by', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
+                ('shared_with', models.ForeignKey(related_name='problem_builder_shared_with', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
         ),
         migrations.AlterUniqueTogether(

--- a/problem_builder/models.py
+++ b/problem_builder/models.py
@@ -68,10 +68,10 @@ class Share(models.Model):
     to query for arbitrary anonymous user IDs. In order to make sharing work, we have
     to store them here.
     """
-    shared_by = models.ForeignKey(User, related_name='problem_builder_shared_by')
+    shared_by = models.ForeignKey(User, related_name='problem_builder_shared_by', on_delete=models.CASCADE)
     submission_uid = models.CharField(max_length=32)
     block_id = models.CharField(max_length=255, db_index=True)
-    shared_with = models.ForeignKey(User, related_name='problem_builder_shared_with')
+    shared_with = models.ForeignKey(User, related_name='problem_builder_shared_with', on_delete=models.CASCADE)
     notified = models.BooleanField(default=False, db_index=True)
 
     class Meta(object):


### PR DESCRIPTION
edX devstack giving errors with some missing django2 migrations/models requirements
[on_delete required in Django 2.0](https://docs.djangoproject.com/en/1.11/ref/models/fields/#django.db.models.ForeignKey)