### PR TITLE
SE-1917 Replace hacky sleeps with webdriver waits

### DIFF
--- a/problem_builder/tests/integration/base_test.py
+++ b/problem_builder/tests/integration/base_test.py
@@ -45,35 +45,31 @@ class PopupCheckMixin(object):
         submit = mentoring.find_element_by_css_selector('.submit input.input-main')
 
         for index, expected_feedback in enumerate(item_feedbacks):
-            # TODO: replace time.sleep with waiting for elements the selenium way
-            time.sleep(2)
 
+            self.wait_until_exists(prefix + " .choice")
             choice_wrapper = mentoring.find_elements_by_css_selector(prefix + " .choice")[index]
             if do_submit:
                 # clicking on actual radio button
+                self.wait_until_exists(".choice-selector input")
                 choice_wrapper.find_element_by_css_selector(".choice-selector input").click()
                 submit.click()
             self.wait_until_disabled(submit)
-            # XXX: temporary workaround; replace sleep with selenium wait for element
-            time.sleep(3)
+            self.wait_until_exists(".choice-result")
             item_feedback_icon = choice_wrapper.find_element_by_css_selector(".choice-result")
-            # XXX: temporary workaround; replace sleep with selenium wait for element
-            time.sleep(3)
+            self.wait_until_clickable(item_feedback_icon)
             item_feedback_icon.click()  # clicking on item feedback icon
-            # XXX: temporary workaround; replace sleep with selenium wait for element
-            time.sleep(3)
+            self.wait_until_exists(".choice-tips")
             item_feedback_popup = choice_wrapper.find_element_by_css_selector(".choice-tips")
             self.assertTrue(item_feedback_popup.is_displayed())
             self.assertEqual(item_feedback_popup.text, expected_feedback)
 
+            self.wait_until_clickable(item_feedback_popup)
             item_feedback_popup.click()
-            # XXX: temporary workaround; replace sleep with selenium wait for element
-            time.sleep(3)
+            self.wait_until_visible(item_feedback_popup)
             self.assertTrue(item_feedback_popup.is_displayed())
 
             mentoring.find_element_by_css_selector('.title').click()
-            # XXX: temporary workaround; replace sleep with selenium wait for element
-            time.sleep(3)
+            self.wait_until_hidden(item_feedback_popup)
             self.assertFalse(item_feedback_popup.is_displayed())
 
 
@@ -135,9 +131,17 @@ class ProblemBuilderBaseTest(SeleniumXBlockTest, PopupCheckMixin):
                 break
 
     def expect_checkmark_visible(self, visible):
+        if visible:
+            self.wait_until_visible(self.checkmark)
+        else:
+            self.wait_until_hidden(self.checkmark)
         self.assertEqual(self.checkmark.is_displayed(), visible)
 
     def expect_submit_enabled(self, enabled):
+        if enabled:
+            self.wait_until_clickable(self.submit_button)
+        else:
+            self.wait_until_disabled(self.submit_button)
         self.assertEqual(self.submit_button.is_enabled(), enabled)
 
 

--- a/problem_builder/tests/integration/base_test.py
+++ b/problem_builder/tests/integration/base_test.py
@@ -17,8 +17,6 @@
 # along with this program in a file in the toplevel directory called
 # "AGPLv3".  If not, see <http://www.gnu.org/licenses/>.
 #
-import time
-
 import mock
 from xblock.fields import String
 from xblockutils.base_test import SeleniumBaseTest, SeleniumXBlockTest

--- a/problem_builder/tests/integration/test_completion.py
+++ b/problem_builder/tests/integration/test_completion.py
@@ -20,8 +20,6 @@
 
 # Imports ###########################################################
 
-import time
-
 from .base_test import (GetChoices, MentoringAssessmentBaseTest,
                         ProblemBuilderBaseTest)
 

--- a/problem_builder/tests/integration/test_completion.py
+++ b/problem_builder/tests/integration/test_completion.py
@@ -98,8 +98,6 @@ class CompletionBlockTest(CompletionBlockTestMixin, ProblemBuilderBaseTest):
         # The checkbox should be checked (since that's the value we submitted earlier),
         # and "Submit" should be disabled (to discourage submitting the same answer):
         self.expect_checkbox_checked(True)
-        # XXX: hack; use web driver wait correctly
-        time.sleep(3)
         self.expect_checkmark_visible(True)
         self.expect_submit_enabled(False)
 

--- a/problem_builder/tests/integration/test_step_builder.py
+++ b/problem_builder/tests/integration/test_step_builder.py
@@ -289,28 +289,27 @@ class StepBuilderTest(MentoringAssessmentBaseTest, MultipleSliderBlocksTestMixin
 
     def popup_check(self, step_builder, item_feedbacks, prefix='', do_submit=True):
         for index, expected_feedback in enumerate(item_feedbacks):
-            # TODO: replace time.sleep with waiting for elements the selenium way
-            time.sleep(2)
 
+            self.wait_until_exists(prefix + " .choice")
+            self.wait_until_exists(prefix + " .choice .choice-label")
             choice_wrapper = step_builder.find_elements_by_css_selector(prefix + " .choice")[index]
             choice_label = step_builder.find_elements_by_css_selector(prefix + " .choice .choice-label")[index]
             choice_label.click()
-            time.sleep(2)
 
+            self.wait_until_exists(".choice-result")
             item_feedback_icon = choice_wrapper.find_element_by_css_selector(".choice-result")
             item_feedback_icon.click()
-            time.sleep(2)
 
+            self.wait_until_exists(".choice-tips")
             item_feedback_popup = choice_wrapper.find_element_by_css_selector(".choice-tips")
             self.assertTrue(item_feedback_popup.is_displayed())
             self.assertEqual(item_feedback_popup.text, expected_feedback)
 
             item_feedback_popup.click()
-            time.sleep(2)
             self.assertTrue(item_feedback_popup.is_displayed())
 
             step_builder.find_elements_by_css_selector(prefix + ' .question-title')[0].click()
-            time.sleep(2)
+            self.wait_until_hidden(item_feedback_popup)
             self.assertFalse(item_feedback_popup.is_displayed())
 
     def extended_feedback_checks(self, step_builder, controls, expected_results):
@@ -811,8 +810,7 @@ class StepBuilderTest(MentoringAssessmentBaseTest, MultipleSliderBlocksTestMixin
 
     def click_overlay_button(self, overlay_button, overlay_on, color_on=None, color_off=HTMLColors.GREY):
         overlay_button.click()
-        # XXX: hack; actually wait for change
-        time.sleep(3)
+        time.sleep(3) # give some time for changes
         button_border_colors = [
             overlay_button.value_of_css_property('border-top-color'),
             overlay_button.value_of_css_property('border-right-color'),

--- a/problem_builder/tests/integration/test_step_builder.py
+++ b/problem_builder/tests/integration/test_step_builder.py
@@ -810,7 +810,7 @@ class StepBuilderTest(MentoringAssessmentBaseTest, MultipleSliderBlocksTestMixin
 
     def click_overlay_button(self, overlay_button, overlay_on, color_on=None, color_off=HTMLColors.GREY):
         overlay_button.click()
-        time.sleep(3) # give some time for changes
+        time.sleep(3)  # give some time for changes
         button_border_colors = [
             overlay_button.value_of_css_property('border-top-color'),
             overlay_button.value_of_css_property('border-right-color'),


### PR DESCRIPTION
The tests don't appear to be flaky on my machine with python 3 any more, but this at least removes the hacky manual sleeps where possible. Instead it relies on webdriver waiting for changes to happen (element to exist, become visible, etc.). This will be faster and more reliable.

**Test instructions**:

- sanity check the code to make sure the test semantics haven't been changed
- verify that tests in CI reliably pass

**Reviewer**:

- [ ] @pomegranited 