### PR TITLE
MCKIN-21527 Problem Builder (FTE, Assessment, MCQ, MRQ) - On opening these modules, none of the text is translated on notifications dropdown.

### DIFF
--- a/problem_builder/instructor_tool.py
+++ b/problem_builder/instructor_tool.py
@@ -176,9 +176,7 @@ class InstructorToolBlock(XBlock, I18NService):
                 new_lang = language[0] + "_" + language[1].upper()
             else:
                 new_lang = utils.translation.get_language()
-            return self.resource_string('public/js/translations/{lang}/textjs.js'.format(
-                lang=new_lang
-            ))
+            return self.resource_string('public/js/translations/{lang}/textjs.js'.format(lang=new_lang))
         except IOError:
             return self.resource_string('public/js/translations/en/textjs.js')
 

--- a/problem_builder/public/js/instructor_tool.js
+++ b/problem_builder/public/js/instructor_tool.js
@@ -214,11 +214,6 @@ function InstructorToolBlock(runtime, element) {
         el: $element.find('.data-export-status')
     });
 
-    // Set up gettext in case it isn't available in the client runtime:
-    if (typeof gettext == "undefined") {
-        window.gettext = function gettext_stub(string) { return string; };
-        window.ngettext = function ngettext_stub(strA, strB, n) { return n == 1 ? strA : strB; };
-    }
     var $startButton = $element.find('.data-export-start');
     var $cancelButton = $element.find('.data-export-cancel');
     var $downloadButton = $element.find('.data-export-download');
@@ -346,7 +341,7 @@ function InstructorToolBlock(runtime, element) {
         root = data.blocks[data.root];
 
         // Label the root block as "All"
-        root.name = gettext('All');
+        root.name = pb_gettext('All');
 
         // Remove any existing options
         $rootBlockId.empty();
@@ -405,14 +400,14 @@ function InstructorToolBlock(runtime, element) {
                 hideResults();
                 hideSpinner();
                 showStatusMessage(_.template(
-                    gettext('Data export failed. Reason: <%= error %>'),
+                    pb_gettext('Data export failed. Reason: <%= error %>'),
                     {'error': status.last_export_result.error}
                 ));
             } else {
                 startTime = new Date(status.last_export_result.start_timestamp * 1000);
                 showInfo(
                     _.template(
-                        ngettext(
+                        pb_ngettext(
                             'Results retrieved on <%= creation_time %> (<%= seconds %> second).',
                             'Results retrieved on <%= creation_time %> (<%= seconds %> seconds).',
                             status.last_export_result.generation_time_s.toFixed(1)
@@ -426,7 +421,7 @@ function InstructorToolBlock(runtime, element) {
             }
         } else {
             if (status.export_pending) {
-                showStatusMessage(gettext('The report is currently being generated…'));
+                showStatusMessage(pb_gettext('The report is currently being generated…'));
             } else {
                 hideSpinner();
             }

--- a/problem_builder/public/js/mentoring_with_steps.js
+++ b/problem_builder/public/js/mentoring_with_steps.js
@@ -1,11 +1,5 @@
 function MentoringWithStepsBlock(runtime, element) {
 
-    // Set up gettext in case it isn't available in the client runtime:
-    if (typeof gettext == "undefined") {
-        window.gettext = function gettext_stub(string) { return string; };
-        window.ngettext = function ngettext_stub(strA, strB, n) { return n == 1 ? strA : strB; };
-    }
-
     var children = runtime.children(element);
 
     var steps = [];

--- a/problem_builder/public/js/mentoring_with_steps.js
+++ b/problem_builder/public/js/mentoring_with_steps.js
@@ -84,15 +84,15 @@ function MentoringWithStepsBlock(runtime, element) {
         if (response.step_status === 'correct') {
             checkmark.addClass('checkmark-correct icon-ok fa-check');
             checkmark.attr('aria-label', checkmark.data('label_correct'));
-            checkmark.append('<span class="sr-only">'+gettext("Correct")+'</span>')
+            checkmark.append('<span class="sr-only">'+pb_gettext("Correct")+'</span>')
         } else if (response.step_status === 'partial') {
             checkmark.addClass('checkmark-partially-correct icon-ok fa-check');
             checkmark.attr('aria-label', checkmark.data('label_partial'));
-            checkmark.append('<span class="sr-only">'+gettext("Partially correct")+'</span>')
+            checkmark.append('<span class="sr-only">'+pb_gettext("Partially correct")+'</span>')
         } else {
             checkmark.addClass('checkmark-incorrect icon-exclamation fa-exclamation');
             checkmark.attr('aria-label', checkmark.data('label_incorrect'));
-            checkmark.append('<span class="sr-only">'+gettext("Incorrect")+'</span>');
+            checkmark.append('<span class="sr-only">'+pb_gettext("Incorrect")+'</span>');
         }
         var step = getActiveStep();
         if (typeof step.showFeedback == 'function') {

--- a/problem_builder/public/js/questionnaire.js
+++ b/problem_builder/public/js/questionnaire.js
@@ -137,12 +137,12 @@ function MCQBlock(runtime, element) {
                     choiceDOM.addClass('correct');
                     choiceResultDOM.addClass('checkmark-correct icon-ok fa-check');
                     choiceResultDOM.attr('aria-label', choiceResultDOM.data('label_correct'));
-                    choiceResultDOM.append('<span class="sr-only">'+gettext("Correct")+'</span>');
+                    choiceResultDOM.append('<span class="sr-only">'+pb_gettext("Correct")+'</span>');
                 } else {
                     choiceDOM.addClass('incorrect');
                     choiceResultDOM.addClass('checkmark-incorrect icon-exclamation fa-exclamation');
                     choiceResultDOM.attr('aria-label', choiceResultDOM.data('label_incorrect'));
-                    choiceResultDOM.append('<span class="sr-only">'+gettext("Incorrect")+'</span>');
+                    choiceResultDOM.append('<span class="sr-only">'+pb_gettext("Incorrect")+'</span>');
                 }
                 choiceResultDOM.off('click').on('click', function() {
                     if (choiceTipsDOM.html() !== '') {
@@ -239,12 +239,12 @@ function MRQBlock(runtime, element) {
                         choiceDOM.addClass('correct');
                         choiceResultDOM.addClass('checkmark-correct icon-ok fa-check');
                         choiceResultDOM.attr('aria-label', choiceResultDOM.data('label_correct'));
-                        choiceResultDOM.append('<span class="sr-only">'+gettext("Correct")+'</span>');
+                        choiceResultDOM.append('<span class="sr-only">'+pb_gettext("Correct")+'</span>');
                     } else if (!choice.completed) {
                         choiceDOM.addClass('incorrect');
                         choiceResultDOM.addClass('checkmark-incorrect icon-exclamation fa-exclamation');
                         choiceResultDOM.attr('aria-label', choiceResultDOM.data('label_incorrect'));
-                        choiceResultDOM.append('<span class="sr-only">'+gettext("Incorrect")+'</span>');
+                        choiceResultDOM.append('<span class="sr-only">'+pb_gettext("Incorrect")+'</span>');
                     }
 
                     mentoring.setContent(choiceTipsDOM, choice.tips);

--- a/problem_builder/public/js/step_util.js
+++ b/problem_builder/public/js/step_util.js
@@ -120,11 +120,15 @@
 
 var gettext;
 var ngettext;
+// create problem builder global translation variables to avoid the overriding of global edxapp translation
+var pb_gettext;
+var pb_ngettext;
 if ('ProblemBuilderXBlockI18N' in window) {
     // Use problem builder's local translations
-    gettext = window.ProblemBuilderXBlockI18N.gettext;
-    ngettext = window.ProblemBuilderXBlockI18N.ngettext;
-} else if ('gettext' in window) {
+    pb_gettext = window.ProblemBuilderXBlockI18N.gettext;
+    pb_ngettext = window.ProblemBuilderXBlockI18N.ngettext;
+}
+if ('gettext' in window) {
     // Use edxapp's global translations
     gettext = window.gettext;
     ngettext = window.ngettext;

--- a/problem_builder/public/js/util.js
+++ b/problem_builder/public/js/util.js
@@ -40,11 +40,17 @@ window.ProblemBuilderUtil = {
 
 var gettext;
 var ngettext;
+// create problem builder global translation variables to avoid the overriding of global edxapp translation
+var pb_gettext;
+var pb_ngettext;
+
 if ('ProblemBuilderXBlockI18N' in window) {
     // Use problem builder's local translations
-    gettext = window.ProblemBuilderXBlockI18N.gettext;
-    ngettext = window.ProblemBuilderXBlockI18N.ngettext;
-} else if ('gettext' in window) {
+    pb_gettext = window.ProblemBuilderXBlockI18N.gettext;
+    pb_ngettext = window.ProblemBuilderXBlockI18N.ngettext;
+}
+
+if ('gettext' in window) {
     // Use edxapp's global translations
     gettext = window.gettext;
     ngettext = window.ngettext;

--- a/problem_builder/questionnaire.py
+++ b/problem_builder/questionnaire.py
@@ -119,9 +119,10 @@ class QuestionnaireAbstractBlock(
         # We use an inline import here to avoid a circular dependency with the .mentoring module.
         if not isinstance(block_with_resources, MentoringBlock):
             block_with_resources = self
+        fragment.add_javascript(self.get_translation_content())
+        fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/step_util.js'))
         fragment.add_css_url(self.runtime.local_resource_url(block_with_resources, 'public/css/questionnaire.css'))
         fragment.add_javascript_url(self.runtime.local_resource_url(block_with_resources, 'public/js/questionnaire.js'))
-        fragment.add_javascript(self.get_translation_content())
         fragment.initialize_js(name)
         return fragment
 

--- a/problem_builder/templates/html/mentoring_attempts.underscore
+++ b/problem_builder/templates/html/mentoring_attempts.underscore
@@ -2,9 +2,9 @@
   <% if (_.isNumber(max_attempts) && max_attempts > 0) {{ %>
   <span>
   	<%= _.template(
-	    ngettext("You have used {num_used} of 1 submission.", "You have used {num_used} of {max_attempts} submissions.", max_attempts),
+	    pb_ngettext("You have used {num_used} of 1 submission.", "You have used {num_used} of {max_attempts} submissions.", max_attempts),
 	    {num_used: _.min([num_attempts, max_attempts]), max_attempts: max_attempts}, {interpolate: /\{(.+?)\}/g}
-	  ) 
+	  )
 	  %>
   </span>
   <% }} %>

--- a/problem_builder/tests/unit/test_instructor_tool.py
+++ b/problem_builder/tests/unit/test_instructor_tool.py
@@ -5,7 +5,6 @@ import unittest
 
 import ddt
 from mock import Mock, patch
-from problem_builder.utils import DummyTranslationService
 from xblock.field_data import DictFieldData
 
 from problem_builder.instructor_tool import (COURSE_BLOCKS_API,
@@ -37,6 +36,8 @@ class TestInstructorToolBlock(unittest.TestCase):
     def setUp(self):
         self.course_id = 'course-v1:edX+DemoX+Demo_Course'
         self.runtime_mock = Mock()
+        self.service_mock = Mock()
+        self.runtime_mock.service = Mock(return_value=self.service_mock)
         self.runtime_mock.get_block = self._get_block
         self.runtime_mock.course_id = self.course_id
         scope_ids_mock = Mock()
@@ -44,7 +45,6 @@ class TestInstructorToolBlock(unittest.TestCase):
         self.block = InstructorToolBlock(
             self.runtime_mock, field_data=DictFieldData({}), scope_ids=scope_ids_mock
         )
-        self.i18n_mock = DummyTranslationService()
 
     def test_student_view_template_args(self):
         """
@@ -59,13 +59,14 @@ class TestInstructorToolBlock(unittest.TestCase):
         }
 
         with patch('problem_builder.instructor_tool.loader') as patched_loader:
-            patched_loader.render_template.return_value = u''
+            patched_loader.render_django_template.return_value = u''
             self.block.student_view()
+            self.service_mock.i18n_service = Mock(return_value=None)
             patched_loader.render_django_template.assert_called_once_with('templates/html/instructor_tool.html', {
                 'block_choices': block_choices,
                 'course_blocks_api': COURSE_BLOCKS_API,
                 'root_block_id': self.course_id,
-            }, i18n_service=self.i18n_mock)
+            }, i18n_service=self.service_mock)
 
     def test_author_view(self):
         """

--- a/problem_builder/tests/unit/test_instructor_tool.py
+++ b/problem_builder/tests/unit/test_instructor_tool.py
@@ -5,6 +5,7 @@ import unittest
 
 import ddt
 from mock import Mock, patch
+from problem_builder.utils import DummyTranslationService
 from xblock.field_data import DictFieldData
 
 from problem_builder.instructor_tool import (COURSE_BLOCKS_API,
@@ -43,6 +44,7 @@ class TestInstructorToolBlock(unittest.TestCase):
         self.block = InstructorToolBlock(
             self.runtime_mock, field_data=DictFieldData({}), scope_ids=scope_ids_mock
         )
+        self.i18n_mock = DummyTranslationService()
 
     def test_student_view_template_args(self):
         """
@@ -59,11 +61,11 @@ class TestInstructorToolBlock(unittest.TestCase):
         with patch('problem_builder.instructor_tool.loader') as patched_loader:
             patched_loader.render_template.return_value = u''
             self.block.student_view()
-            patched_loader.render_template.assert_called_once_with('templates/html/instructor_tool.html', {
+            patched_loader.render_django_template.assert_called_once_with('templates/html/instructor_tool.html', {
                 'block_choices': block_choices,
                 'course_blocks_api': COURSE_BLOCKS_API,
                 'root_block_id': self.course_id,
-            })
+            }, i18n_service=self.i18n_mock)
 
     def test_author_view(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools.command.install import install
 
 # Constants #########################################################
 
-VERSION = '3.4.22'
+VERSION = '3.4.23'
 
 # Functions #########################################################
 


### PR DESCRIPTION
**Issue:**
Problem Builder's `gettext` and `ngettext` override the global translations of the edx app. Hence strings of apps added outside the scope of problem builder doesn't get translated specially edx-notification, this is due to the step_util.js and util.js in which `gettext` and `ngetext` are declared globally.

**Solution:**  
New variables are introduced for the problem builder i.e `pb_gettext` and `pb_ngettext` so that global `gettext` and `ngettext` don't get overridden and their usage is updated elsewhere.
