### PR TITLE
Add translations to the package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup(
     entry_points={
         'xblock.v1': BLOCKS,
     },
-    package_data=package_data("problem_builder", ["templates", "public", "migrations", "locale"]),
+    package_data=package_data("problem_builder", ["templates", "public", "migrations", "translations"]),
     cmdclass={
         'verify_tag': VerifyTagCommand,
     },


### PR DESCRIPTION
## Description
Since the translation is not included in the package data the following error is raised` FileNotFoundError: [Errno 2] No such file or directory: '/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/problem_builder/translations/config.yaml'`, so this forces to  install  the package from github in editable mode.

This pr includes the translation in the package data an remove locale