### PR TITLE
Fix deprecated import path

### DIFF
--- a/problem_builder/models.py
+++ b/problem_builder/models.py
@@ -20,14 +20,21 @@
 
 # Imports ###########################################################
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models
 from django.db.models.signals import pre_delete
 
 try:
     # workaround so we don't explicitly import the AnonymousUserId model from LMS
-    from student.models import AnonymousUserId
+    if "common.djangoapps.student.apps.StudentConfig" in settings.INSTALLED_APPS:
+        # Koa and beyond:
+        from common.djangoapps.student.models import AnonymousUserId
+    else:
+        # Juniper and earlier
+        from student.models import AnonymousUserId
 except ImportError:
+    # Not running the LMS (e.g. tests)
     AnonymousUserId = None
 
 


### PR DESCRIPTION
Removes this warning on newer edX versions (Koa and forward):

```
2020-11-24 20:33:43,166 WARNING 4695 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/src/problem-builder/problem_builder/models.py:29: DeprecatedEdxPlatformImportWarning: Importing student instead of common.djangoapps.student is deprecated
  from student.models import AnonymousUserId
```

Backwards compatible with Juniper and Ironwood.