### PR TITLE
MCKIN-28611 - Nested blocks imports fix

### DIFF
--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -335,9 +335,9 @@ class MentoringBlock(
         """
         additional_blocks = []
         try:
-            from xmodule.video_module.video_module import VideoDescriptor
+            from xmodule.video_module.video_module import VideoBlock
             additional_blocks.append(NestedXBlockSpec(
-                VideoDescriptor, category='video', label=_(u"Video")
+                VideoBlock, category='video', label=_(u"Video")
             ))
         except ImportError:
             pass
@@ -358,7 +358,7 @@ class MentoringBlock(
             pass
 
         try:
-            from ooyala_player import OoyalaPlayerBlock
+            from ooyala_player.ooyala_player import OoyalaPlayerBlock
             additional_blocks.append(NestedXBlockSpec(
                 OoyalaPlayerBlock, category='ooyala-player', label=_(u"Ooyala Player")
             ))

--- a/problem_builder/step.py
+++ b/problem_builder/step.py
@@ -136,9 +136,9 @@ class MentoringStepBlock(
         """
         additional_blocks = []
         try:
-            from xmodule.video_module.video_module import VideoDescriptor
+            from xmodule.video_module.video_module import VideoBlock
             additional_blocks.append(NestedXBlockSpec(
-                VideoDescriptor, category='video', label=_(u"Video")
+                VideoBlock, category='video', label=_(u"Video")
             ))
         except ImportError:
             pass
@@ -151,7 +151,7 @@ class MentoringStepBlock(
             pass
 
         try:
-            from ooyala_player import OoyalaPlayerBlock
+            from ooyala_player.ooyala_player import OoyalaPlayerBlock
             additional_blocks.append(NestedXBlockSpec(
                 OoyalaPlayerBlock, category='ooyala-player', label=_(u"Ooyala Player")
             ))

--- a/problem_builder/tests/unit/utils.py
+++ b/problem_builder/tests/unit/utils.py
@@ -68,7 +68,7 @@ class BlockWithChildrenTestMixin:
             'xmodule.video_module': xmodule_mock.video_module,
             'xmodule.video_module.video_module': xmodule_mock.video_module.video_module,
             'imagemodal': Mock(),
-            'ooyala_player': Mock(),
+            'ooyala_player.ooyala_player': Mock(),
         }
         with patch.dict(modules, fake_modules):
             self.assertEqual(

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools.command.install import install
 
 # Constants #########################################################
 
-VERSION = '4.1.7'
+VERSION = '4.1.8'
 
 # Functions #########################################################
 


### PR DESCRIPTION
Fix imports of Video and Ooyala blocks for Juniper: 
-  `VideoDescriptor` has been replaced with [VideoBlock](https://github.com/edx/edx-platform/blob/open-release/juniper.master/common/lib/xmodule/xmodule/video_module/video_module.py#L113) 
- Imports have been [removed](https://github.com/edx-solutions/xblock-ooyala/pull/120/files) from __init__ file 