### PR TITLE
Import from common.djangoapps.student.models more reliably

### DIFF
--- a/problem_builder/models.py
+++ b/problem_builder/models.py
@@ -20,22 +20,25 @@
 
 # Imports ###########################################################
 
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models
 from django.db.models.signals import pre_delete
 
 try:
-    # workaround so we don't explicitly import the AnonymousUserId model from LMS
-    if "common.djangoapps.student.apps.StudentConfig" in settings.INSTALLED_APPS:
-        # Koa and beyond:
+    # Koa and earlier: use shortened import path.
+    # This will raise a warning in Koa, but that's OK.
+    from student.models import AnonymousUserId
+except Exception:  # pylint: disable=broad-except
+    # (catch broadly, since the exception could manifest as either an ImportError
+    #  or an EdxPlatformDeprecatedImportError, the latter of which is not a subclass
+    #  of the former, and only exists on edx-platform master between Koa and Lilac).
+    try:
+        # Post-Koa: we must use the full import path.
         from common.djangoapps.student.models import AnonymousUserId
-    else:
-        # Juniper and earlier
-        from student.models import AnonymousUserId
-except ImportError:
-    # Not running the LMS (e.g. tests)
-    AnonymousUserId = None
+    except ImportError:
+        # If we get here, we are not running within edx-platform
+        # (e.g., we are running problem-builder unit tests).
+        AnonymousUserId = None
 
 
 # Classes ###########################################################

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools.command.install import install
 
 # Constants #########################################################
 
-VERSION = '4.1.9'
+VERSION = '4.1.10'
 
 # Functions #########################################################
 


### PR DESCRIPTION
## Context

`common.djangoapps.student.models` must be imported differently depending on whether we're installed into a pre-Koa or post-Koa edx-platform. Koa itself can handle both import forms but raises a warning on the shortened form. See [this forum thread on import changes](https://discuss.openedx.org/t/koa-will-change-how-edx-platform-code-is-imported/3610) for more details).

## Issue

Problem-builder currently decides which import path to use by looking at `settings.INSTALLED_APPS`. That works most of the time, but breaks in certain special contexts like Celery workers, which don't have the same list of installed apps. On edx.org staging yesterday we saw:
```
  File "/edx/app/edxapp/venvs/edxapp/bin/celery", line 8, in <module>
    sys.exit(main())
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/celery/__main__.py", line 16, in main
    _main()
  ... many frames ...
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/problem_builder/models.py", line 29, in <module>
    from student.models import AnonymousUserId
  File "/edx/app/edxapp/edx-platform/import_shims/lms/student/__init__.py", line 6, in <module>
    warn_deprecated_import('student', 'common.djangoapps.student')
  File "/edx/app/edxapp/edx-platform/import_shims/warn.py", line 64, in warn_deprecated_import
    raise DeprecatedEdxPlatformImportError(old_import, new_import)
import_shims.warn.DeprecatedEdxPlatformImportError: Importing student instead of common.djangoapps.student is deprecated
```

## Solution

Instead, just rely on exception handling. In Koa, this will re-introduce an EdxPlatformDeprecatedImportWarning. This seems acceptable given that other workaround would involve making the import logic even more complex.

(There are ways to do this without bringing the EdxPlatformDeprecatedImportWarning back for Koa, but they would involve really hacky stuff like checking the value of `sys.path`.)

This should be compatible with any Open edX release Lilac and earlier.

Bumps version to 4.1.10.




