### PR TITLE
fix: deprecated edx-platform import references

### DIFF
--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -349,13 +349,11 @@ class MentoringBlock(
         except ImportError:
             pass
 
-        try:
-            from xblock_django.models import XBlockConfiguration
+        from .platform_dependencies import XBlockConfiguration
+        if XBlockConfiguration:
             opt = XBlockConfiguration.objects.filter(name="pb-swipe")
             if opt.count() and opt.first().enabled:
                 additional_blocks.append(SwipeBlock)
-        except ImportError:
-            pass
 
         try:
             from ooyala_player.ooyala_player import OoyalaPlayerBlock

--- a/problem_builder/mixins.py
+++ b/problem_builder/mixins.py
@@ -287,11 +287,9 @@ class ExpandStaticURLMixin:
         elif hasattr(self.runtime, 'course_id'):
             # edX Studio uses a different runtime for 'studio_view' than 'student_view',
             # and the 'studio_view' runtime doesn't provide the replace_urls API.
-            try:
-                from static_replace import replace_static_urls  # pylint: disable=import-error
+            from .platform_dependencies import replace_static_urls
+            if replace_static_urls:
                 text = replace_static_urls(text, course_id=self.runtime.course_id)
-            except ImportError:
-                pass
         return text
 
 

--- a/problem_builder/models.py
+++ b/problem_builder/models.py
@@ -24,21 +24,7 @@ from django.contrib.auth.models import User
 from django.db import models
 from django.db.models.signals import pre_delete
 
-try:
-    # Koa and earlier: use shortened import path.
-    # This will raise a warning in Koa, but that's OK.
-    from student.models import AnonymousUserId
-except Exception:  # pylint: disable=broad-except
-    # (catch broadly, since the exception could manifest as either an ImportError
-    #  or an EdxPlatformDeprecatedImportError, the latter of which is not a subclass
-    #  of the former, and only exists on edx-platform master between Koa and Lilac).
-    try:
-        # Post-Koa: we must use the full import path.
-        from common.djangoapps.student.models import AnonymousUserId
-    except ImportError:
-        # If we get here, we are not running within edx-platform
-        # (e.g., we are running problem-builder unit tests).
-        AnonymousUserId = None
+from .platform_dependencies import AnonymousUserId
 
 
 # Classes ###########################################################

--- a/problem_builder/platform_dependencies.py
+++ b/problem_builder/platform_dependencies.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2014-2015 Harvard, edX & OpenCraft
+#
+# This software's license gives you freedom; you can copy, convey,
+# propagate, redistribute and/or modify this program under the terms of
+# the GNU Affero General Public License (AGPL) as published by the Free
+# Software Foundation (FSF), either version 3 of the License, or (at your
+# option) any later version of the AGPL published by the FSF.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program in a file in the toplevel directory called
+# "AGPLv3".  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# PURPOSE OF THIS MODULE:
+# problem-builder has a couple dependencies on models in the edx-platform
+# repository. This comes with two challenges:
+#  1. We cannot import from edx-platform during unit tests, because
+#     it is not installed into the testing environment.
+#  2. Some edx-platform import paths differ between Open edX releases.
+# In the interest of performing these imports in a consistent way,
+# we centralize the imports here, to be re-imported by other modules.
+
+# pylint: disable=unused-import
+
+try:
+    # Koa and earlier: use shortened import path.
+    # This will raise a warning in Koa, but that's OK.
+    from courseware.models import StudentModule
+    from static_replace import replace_static_urls
+    from student.models import AnonymousUserId
+    from xblock_django.models import XBlockConfiguration
+except Exception:  # pylint: disable=broad-except
+    # (catch broadly, since the exception could manifest as either an ImportError
+    #  or an EdxPlatformDeprecatedImportError, the latter of which is not a subclass
+    #  of the former, and only exists on edx-platform master between Koa and Lilac).
+    try:
+        # Post-Koa: we must use the full import path.
+        from lms.djangoapps.courseware.models import StudentModule
+        from common.djangoapps.static_replace import replace_static_urls
+        from common.djangoapps.student.models import AnonymousUserId
+        from common.djangoapps.xblock_django.models import XBlockConfiguration
+    except ImportError:
+        # If we get here, we are not running within edx-platform
+        # (e.g., we are running problem-builder unit tests).
+        StudentModule = None
+        replace_static_urls = None
+        AnonymousUserId = None
+        XBlockConfiguration = None

--- a/problem_builder/swipe.py
+++ b/problem_builder/swipe.py
@@ -151,11 +151,9 @@ class SwipeBlock(
         elif hasattr(self.runtime, 'course_id'):
             # edX Studio uses a different runtime for 'studio_view' than 'student_view',
             # and the 'studio_view' runtime doesn't provide the replace_urls API.
-            try:
-                from static_replace import replace_static_urls  # pylint: disable=import-error
+            from .platform_dependencies import replace_static_urls
+            if replace_static_urls:
                 url = replace_static_urls('"{}"'.format(url), None, course_id=self.runtime.course_id)[1:-1]
-            except ImportError:
-                pass
         return url
 
     def mentoring_view(self, context=None):

--- a/problem_builder/v1/upgrade.py
+++ b/problem_builder/v1/upgrade.py
@@ -37,12 +37,16 @@ import six
 from lxml import etree
 from six import StringIO
 
-from courseware.models import StudentModule
 from mentoring import MentoringBlock
 from problem_builder.mentoring import MentoringBlock as NewMentoringBlock
 
+from .platform_dependencies import StudentModule
 from .studio_xml_utils import studio_update_from_node
 from .xml_changes import convert_xml_to_v2
+
+
+if not StudentModule:
+    raise ImportError("Could not import StudentModule from edx-platform courseware app.")
 
 
 def upgrade_block(store, block, from_version="v1"):

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools.command.install import install
 
 # Constants #########################################################
 
-VERSION = '4.1.10'
+VERSION = '4.1.11'
 
 # Functions #########################################################
 


### PR DESCRIPTION
Commit:
```
For Lilac and beyond, make sure the following:
* courseware
* static_replace
* xblock_django

are instead imported as:
* lms.djangoapps.courseware
* common.djangoapps.static_replace
* common.djangoapps.xblock_django

refactor: centralize logic of edx-platform imports
in new module platform_dependencies.py.

Bump version to 4.1.11
```

Check out https://github.com/open-craft/problem-builder/pull/323 for context on the underlying import issue and our approach for handling it across different Open edX releases.

This PR just takes the strategy from #323 and applies it to three other instances of deprecated edx-platform imports. It centralizes the logic in a new file `platform_dependencies.py` as to avoid duplicating the nested `try-except` block across the project.

Related to the [import shims removal](https://github.com/edx/edx-platform/pull/25932)