### PR TITLE
MEI-7001 add exception handling in case question deleted

### DIFF
--- a/problem_builder/mentoring.py
+++ b/problem_builder/mentoring.py
@@ -890,12 +890,15 @@ class MentoringWithExplicitStepsBlock(BaseMentoringBlock, StudioContainerWithNes
         for step in steps:
             for answer in step.student_results:
                 if answer[1]['status'] == answer_status:
-                    answer_map.append({
-                        'id': answer[0],
-                        'details': answer[1],
-                        'step': step.step_number,
-                        'number': self.get_question_number(answer[0]),
-                    })
+                    try:
+                        answer_map.append({
+                            'id': answer[0],
+                            'details': answer[1],
+                            'step': step.step_number,
+                            'number': self.get_question_number(answer[0]),
+                        })
+                    except ValueError:
+                        pass  # The question has been deleted since the student answered it.
         return answer_map
 
     @property

--- a/problem_builder/platform_dependencies.py
+++ b/problem_builder/platform_dependencies.py
@@ -29,11 +29,11 @@
 
 # pylint: disable=unused-import
 
-# TODO: It might make sense to handle imports seprately
-# implemention here that just segregates StudentModule import form others
-# to avoid conflicting 'studentmodule' models for juniper. Previously,
-# `RuntimeError` due to this, causes other modules to be imported as
-# full import path which juniper don't support.
+# TODO: It might make sense to handle imports separately. This part just
+#  separates the `StudentModule` import from others to avoid conflicting
+#  with `studentmodule` models in Juniper. Without this, a `RuntimeError`
+#  is raised, as it causes other modules to be imported with a full import
+#  path, which is not supported in Juniper.
 try:
     from courseware.models import StudentModule
 except Exception:

--- a/problem_builder/platform_dependencies.py
+++ b/problem_builder/platform_dependencies.py
@@ -30,9 +30,18 @@
 # pylint: disable=unused-import
 
 try:
+    from courseware.models import StudentModule
+except Exception:
+    try:
+        from lms.djangoapps.courseware.models import StudentModule
+    except ImportError:
+        # If we are not running within edx-platform
+        # (e.g., we are running problem-builder unit tests).
+        StudentModule = None
+
+try:
     # Koa and earlier: use shortened import path.
     # This will raise a warning in Koa, but that's OK.
-    from courseware.models import StudentModule
     from static_replace import replace_static_urls
     from student.models import AnonymousUserId
     from xblock_django.models import XBlockConfiguration
@@ -42,14 +51,12 @@ except Exception:  # pylint: disable=broad-except
     #  of the former, and only exists on edx-platform master between Koa and Lilac).
     try:
         # Post-Koa: we must use the full import path.
-        from lms.djangoapps.courseware.models import StudentModule
         from common.djangoapps.static_replace import replace_static_urls
         from common.djangoapps.student.models import AnonymousUserId
         from common.djangoapps.xblock_django.models import XBlockConfiguration
     except ImportError:
         # If we get here, we are not running within edx-platform
         # (e.g., we are running problem-builder unit tests).
-        StudentModule = None
         replace_static_urls = None
         AnonymousUserId = None
         XBlockConfiguration = None

--- a/problem_builder/platform_dependencies.py
+++ b/problem_builder/platform_dependencies.py
@@ -29,6 +29,11 @@
 
 # pylint: disable=unused-import
 
+# TODO: It might make sense to handle imports seprately
+# implemention here that just segregates StudentModule import form others
+# to avoid conflicting 'studentmodule' models for juniper. Previously,
+# `RuntimeError` due to this, causes other modules to be imported as
+# full import path which juniper don't support.
 try:
     from courseware.models import StudentModule
 except Exception:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools.command.install import install
 
 # Constants #########################################################
 
-VERSION = '4.1.12'
+VERSION = '4.1.13'
 
 # Functions #########################################################
 


### PR DESCRIPTION
Jira ticket: https://mckinsey.atlassian.net/browse/MEI-7001

Context
======
Participant should be able to submit/go through the assessment if a course author makes some changes(like deleting or reauthoring any question) in assessment through the studio.

Issue
====
Problem builder xblock does not load or gets stuck and raises value error after a question being deleted by the course author. This issue impacts only those users who had already submitted that question. Error trace from the logs as shown below:

![Screenshot from 2021-04-13 13-10-12(1)](https://user-images.githubusercontent.com/41048311/115589599-76d9d880-a2e9-11eb-89f1-61f90e02e3fa.png)

In order to reproduce this issue, delete a question from the studio and make few changes in question choices as well.
Before publishing the changes, start attempting the assessment and then start attempting the assessment again (to complete it) after publishing the changes. By this, a value error will raise and you will not able to proceed further.

Testing instructions
==============
Testing instructions would be the same as defined to reproduce.  

The reviewer should be able to use assessment without issue after checking out to this branch(**mudassir-hafeez:MEI-7001**).


