### PR TITLE
feat: add support for celery 5.x

### DIFF
--- a/problem_builder/tasks.py
+++ b/problem_builder/tasks.py
@@ -3,7 +3,7 @@ Celery task for CSV student answer export.
 """
 import time
 
-from celery.task import task
+from celery import shared_task
 from celery.utils.log import get_task_logger
 from django.contrib.auth.models import User
 from django.db.models import F
@@ -23,7 +23,7 @@ from .sub_api import sub_api
 logger = get_task_logger(__name__)
 
 
-@task()
+@shared_task()
 def export_data(course_id, source_block_id_str, block_types, user_ids, match_string):
     """
     Exports student answers to all supported questions to a CSV file.

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ from setuptools.command.install import install
 
 # Constants #########################################################
 
-VERSION = '5.0.0'
+VERSION = '5.1.0'
 
 # Functions #########################################################
 


### PR DESCRIPTION
While testing celery upgrade PR in the edx-platform (https://github.com/edx/edx-platform/pull/29046/), found out that this xblock isn't compatible with celery 5.x. So this PR is making this xblock celery 5.x compatible. This xblock is private requirement of edx-platform